### PR TITLE
simplify action creators

### DIFF
--- a/src/modules/common/actions/login.js
+++ b/src/modules/common/actions/login.js
@@ -2,21 +2,17 @@ import oauth from 'panoptes-client/lib/oauth';
 import * as types from '../../../constants/action-types';
 
 export function setLoginUser(user) {
-  return (dispatch) => {
-    dispatch({
-      type: types.SET_LOGIN_USER,
-      user,
-    });
+  return {
+    type: types.SET_LOGIN_USER,
+    user,
   };
 }
 
-export function checkLoginUser() {  // First thing on app load - check if the user is logged in.
-  return (dispatch) => {
-    oauth.checkCurrent()
-      .then((user) => {
-        dispatch(setLoginUser(user));
-      });
-  };
+export function checkLoginUser(dispatch) {
+  oauth.checkCurrent()
+    .then((user) => {
+      dispatch(setLoginUser(user));
+    });
 }
 
 function computeRedirectURL(window) {
@@ -24,15 +20,13 @@ function computeRedirectURL(window) {
     `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
 }
 
-export function loginToPanoptes() {  // Returns a login page URL for the user to navigate to.
-  return (() => oauth.signIn(computeRedirectURL(window)));
+export function loginToPanoptes() {
+  oauth.signIn(computeRedirectURL(window));
 }
 
-export function logoutFromPanoptes() {
-  return (dispatch) => {
-    oauth.signOut()
-      .then((user) => {
-        dispatch(setLoginUser(user));
-      });
-  };
+export function logoutFromPanoptes(dispatch) {
+  oauth.signOut()
+    .then((user) => {
+      dispatch(setLoginUser(user));
+    });
 }

--- a/src/modules/common/actions/organizations.js
+++ b/src/modules/common/actions/organizations.js
@@ -1,13 +1,13 @@
 import * as types from '../../../constants/action-types';
 
-export function setCurrentOrganization(organization) { // eslint-disable-line import/prefer-default-export
+export function setCurrentOrganization(organization) {
   return {
     type: types.SET_CURRENT_ORGANIZATION,
     organization,
   };
 }
 
-export function setOrganizations(organizations) { // eslint-disable-line import/prefer-default-export
+export function setOrganizations(organizations) {
   return {
     type: types.SET_ORGANIZATIONS,
     organizations,

--- a/src/modules/common/actions/organizations.js
+++ b/src/modules/common/actions/organizations.js
@@ -1,19 +1,15 @@
 import * as types from '../../../constants/action-types';
 
 export function setCurrentOrganization(organization) { // eslint-disable-line import/prefer-default-export
-  return (dispatch) => {
-    dispatch({
-      type: types.SET_CURRENT_ORGANIZATION,
-      organization,
-    });
+  return {
+    type: types.SET_CURRENT_ORGANIZATION,
+    organization,
   };
 }
 
 export function setOrganizations(organizations) { // eslint-disable-line import/prefer-default-export
-  return (dispatch) => {
-    dispatch({
-      type: types.SET_ORGANIZATIONS,
-      organizations,
-    });
+  return {
+    type: types.SET_ORGANIZATIONS,
+    organizations,
   };
 }

--- a/src/modules/common/containers/header-auth.jsx
+++ b/src/modules/common/containers/header-auth.jsx
@@ -9,30 +9,25 @@ import LoginButton from '../components/login-button';
 import LogoutButton from '../components/logout-button';
 
 class HeaderAuth extends React.Component {
-  constructor() {
-    super();
-    this.login = this.login.bind(this);
+  constructor(props) {
+    super(props);
     this.logout = this.logout.bind(this);
   }
 
   componentDidMount() {
     if (!this.props.initialized) {
-      this.props.dispatch(checkLoginUser());
+      checkLoginUser(this.props.dispatch);
     }
   }
 
-  login() {
-    return this.props.dispatch(loginToPanoptes());
-  }
-
   logout() {
-    this.props.dispatch(logoutFromPanoptes());
+    logoutFromPanoptes(this.props.dispatch);
   }
 
   render() {
     return (this.props.user)
       ? <LogoutButton user={this.props.user} logout={this.logout} />
-      : <LoginButton login={this.login} />;
+      : <LoginButton login={loginToPanoptes} />;
   }
 }
 


### PR DESCRIPTION
The action creators we were using in login.js and organizations.js worked but were overly complex. Also, they didn't work with the mock-redux-store testing framework. I've simplified them, which will help us either way, and I'm hoping that the simplified actions will work better with the framework.