### PR TITLE
Oauth and router updates

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ import config from './webpack.config';
 import DashboardPlugin from 'webpack-dashboard/plugin';
 
 const isProduction = process.env.NODE_ENV === 'production';
-const port = isProduction ? process.env.PORT : 3000;
+const port = isProduction ? process.env.PORT : 3737;
 const app = express();
 const indexHtml = path.join(__dirname, 'dist/index.html');
 

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -1,3 +1,3 @@
 export const config = { // eslint-disable-line import/prefer-default-export
-  panoptesAppId: '24ad5676d5d25c6aa850dc5d5f63ec8c03dbc7ae113b6442b8571fce6c5b974c', // test-rog project for dev
+  panoptesAppId: 'a6965f9d7fbe7e921cbf1fc032a02c1b1cc4652cbd6823256a7cc5944ae2c4e1',
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { browserHistory, Router, Route } from 'react-router';
+import { browserHistory, Route, Router } from 'react-router';
 import { Provider } from 'react-redux';
 import oauth from 'panoptes-client/lib/oauth';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -23,11 +23,13 @@ const store = configureStore(initialState);
 
 window.React = React;
 
+// We should use react-router-scroll middleware instead of onUpdate handler
+// But lib still depends on history v3
 oauth.init(config.panoptesAppId)
   .then(() => {
     ReactDOM.render((
       <Provider store={store}>
-        <Router history={browserHistory}>
+        <Router history={browserHistory} onUpdate={() => window.scrollTo(0, 0)}>
           <Route path="/" component={App} >
             {organizationsRoutes(store)}
           </Route>


### PR DESCRIPTION
This updates:
- the port to `3737` to differentiate it from the starter app.
- the client id to use a specific door keeper app in staging. 
- a router onUpdate handler to put the page back to the top. We should be using `react-router-scroll` middleware but it has a peer dep on history v3 and we're using history v4 (Updating this could be a cool open source contrib if anyone fancies that), but this should work in the meantime. 