### PR TITLE
Collaborator creator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     'max-len': [1, 120, 2, {
       'ignoreUrls': true,
       'ignoreComments': false
-    }]
+    }],
+    "radix": ["error", "as-needed"]
   }
 }

--- a/src/modules/common/components/landing.jsx
+++ b/src/modules/common/components/landing.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { ZooniverseLogotype } from 'Zooniverse-react-components';
+import { ZooniverseLogotype } from 'zooniverse-react-components';
 import { loginToPanoptes } from '../../../services/panoptes';
 
 const SignedOut = () =>

--- a/src/modules/common/components/site-footer.jsx
+++ b/src/modules/common/components/site-footer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ZooniverseLogotype } from 'Zooniverse-react-components';
+import { ZooniverseLogotype } from 'zooniverse-react-components';
 import AdminToggle from './admin-toggle';
 
 const SiteFooter = ({ adminMode, toggleAdminMode, user }) =>

--- a/src/modules/common/components/site-nav.jsx
+++ b/src/modules/common/components/site-nav.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { ZooniverseLogo } from 'Zooniverse-react-components';
+import { ZooniverseLogo } from 'zooniverse-react-components';
 import SiteNavItems from './site-nav-items';
 import HeaderAuth from '../containers/header-auth';
 

--- a/src/modules/common/containers/form-container.jsx
+++ b/src/modules/common/containers/form-container.jsx
@@ -4,7 +4,7 @@ export default class FormContainer extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { show: false };
+    this.state = { show: false, submitting: false };
     this.handleChange = this.handleChange.bind(this);
     this.handleReset = this.handleReset.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -12,6 +12,7 @@ export default class FormContainer extends React.Component {
   }
 
   handleChange() {
+    this.props.onChange();
     if (this.state.show === false) {
       this.setState({ show: true });
     }
@@ -26,8 +27,14 @@ export default class FormContainer extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    this.props.onSubmit();
-    this.hideButtons();
+    const submitPromise = new Promise((resolve, reject) => {
+      this.setState({ submitting: true });
+      resolve(this.props.onSubmit());
+    });
+
+    submitPromise
+      .then(() => { this.hideButtons(); })
+      .catch((e) => { console.error(e); });
   }
 
   hideButtons() {
@@ -40,8 +47,14 @@ export default class FormContainer extends React.Component {
         {this.props.children}
         {this.state.show &&
           <div>
-            <button type="submit" onClick={this.handleSubmit}>{this.props.submitLabel}</button>
-            <button type="reset" onClick={this.handleReset}>{this.props.resetLabel}</button>
+            <button
+              type="submit"
+              disabled={this.props.disabledSubmit || this.state.submitting}
+              onClick={this.handleSubmit}
+            >
+              {this.props.submitLabel}
+            </button>
+            <button type="reset" disabled={this.state.submitting} onClick={this.handleReset}>{this.props.resetLabel}</button>
           </div>}
       </form>
     );
@@ -49,16 +62,19 @@ export default class FormContainer extends React.Component {
 }
 
 FormContainer.defaultProps = {
-  resetLabel: 'Cancel',
+  disabledSubmit: false,
   onReset: () => {},
   onSubmit: () => {},
+  resetLabel: 'Cancel',
   submitLabel: 'Save',
 };
 
 FormContainer.propTypes = {
   children: React.PropTypes.node,
-  resetLabel: React.PropTypes.string,
+  disabledSubmit: React.PropTypes.bool,
+  onChange: React.PropTypes.func,
   onReset: React.PropTypes.func.isRequired,
   onSubmit: React.PropTypes.func.isRequired,
+  resetLabel: React.PropTypes.string,
   submitLabel: React.PropTypes.string,
 };

--- a/src/modules/common/containers/form-container.jsx
+++ b/src/modules/common/containers/form-container.jsx
@@ -41,7 +41,7 @@ export default class FormContainer extends React.Component {
 
   render() {
     return (
-      <form onChange={this.handleChange}>
+      <form className="form" onChange={this.handleChange}>
         {this.props.children}
         {this.state.show &&
           <div>

--- a/src/modules/common/containers/form-container.jsx
+++ b/src/modules/common/containers/form-container.jsx
@@ -21,24 +21,22 @@ export default class FormContainer extends React.Component {
   handleReset(e) {
     e.preventDefault();
     this.props.onReset();
-    this.setState({ show: false });
     this.hideButtons();
   }
 
   handleSubmit(e) {
     e.preventDefault();
-    const submitPromise = new Promise((resolve, reject) => {
-      this.setState({ submitting: true });
-      resolve(this.props.onSubmit());
-    });
-
-    submitPromise
-      .then(() => { this.hideButtons(); })
-      .catch((e) => { console.error(e); });
+    this.setState({ submitting: true });
+    this.props.onSubmit();
+    this.hideButtons();
   }
 
   hideButtons() {
-    this.setState({ show: false });
+    if (this.state.submitting) {
+      return this.setState({ show: false, submitting: false });
+    }
+
+    return this.setState({ show: false });
   }
 
   render() {
@@ -63,6 +61,7 @@ export default class FormContainer extends React.Component {
 
 FormContainer.defaultProps = {
   disabledSubmit: false,
+  onChange: () => {},
   onReset: () => {},
   onSubmit: () => {},
   resetLabel: 'Cancel',

--- a/src/modules/organizations/components/edit-collaborators.jsx
+++ b/src/modules/organizations/components/edit-collaborators.jsx
@@ -1,46 +1,11 @@
 import React from 'react';
 
-import { organizationShape, organizationCollaboratorsShape, organizationOwnerShape } from '../model';
+import { organizationCollaboratorsShape, organizationOwnerShape } from '../model';
 
-import bindInput from '../../common/containers/bind-input';
-
-const EditCollaborators = ({ organization, organizationOwner, organizationCollaborators, removeCollaborator, saving, updateCollaborator, user }) => {
+const EditCollaborators = ({ organizationOwner, organizationCollaborators, possibleRoles, removeCollaborator, rolesInfo, saving, updateCollaborator, user }) => {
   if (!organizationCollaborators || !organizationOwner) {
     return <div>Loading...</div>;
   }
-
-  const ID_PREFIX = 'LAB_COLLABORATORS_PAGE_';
-
-  const POSSIBLE_ROLES = {
-    collaborator: 'admin',
-    scientist: 'scientist',
-    moderator: 'moderator',
-    tester: 'team',
-  };
-
-  const ROLES_INFO = {
-    collaborator: {
-      label: 'Collaborator',
-      description: 'Collaborators have full access to edit organization content, including deleting the organization.',
-    },
-    scientist: {
-      label: 'Researcher',
-      description: 'Members of the research team will be marked as researchers on "Talk"',
-    },
-    moderator: {
-      label: 'Moderator',
-      description: 'Moderators have extra privileges in the community discussion area to moderate discussions. They will also be marked as moderators on "Talk".',
-    },
-    tester: {
-      label: 'Tester',
-      description: 'Testers can view (TODO: view what?). They cannot access the organization builder.',
-    },
-    // TODO: uncomment when we can translate
-    // translator: {
-    //   label: 'Translator',
-    //   description: 'Translators will have access to the translation site.',
-    // },
-  };
 
   const toggleRole = (collaborator, event) => {
     updateCollaborator(collaborator, event.target.value, event.target.checked);
@@ -48,11 +13,6 @@ const EditCollaborators = ({ organization, organizationOwner, organizationCollab
 
   const handleRemoval = (collaborator) => {
     removeCollaborator(collaborator);
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    console.log('submit');
   };
 
   return (
@@ -76,7 +36,7 @@ const EditCollaborators = ({ organization, organizationOwner, organizationCollab
                 <button type="button" onClick={handleRemoval.bind(this, collaborator)}>&times;</button>
               </span>
               <br />
-              {Object.keys(POSSIBLE_ROLES).map((role, i) => {
+              {Object.keys(possibleRoles).map((role, i) => {
                 return (
                   <label key={`role-${i}`}>
                     <input
@@ -87,48 +47,22 @@ const EditCollaborators = ({ organization, organizationOwner, organizationCollab
                       value={role}
                       disabled={saving === collaborator.id}
                     />
-                    {ROLES_INFO[role].label}
+                    {rolesInfo[role].label}
                   </label>);
               })}
             </li>);
           })}
         </ul>)}
-
-      <hr />
-
-      <h3 className="form-label">Add another</h3>
-      <form>
-        <div>
-          search placeholder.
-        </div>
-
-        <table className="standard-table">
-          <tbody>
-            {Object.keys(POSSIBLE_ROLES).map((role, i) => {
-              return (
-                <tr key={`${role}-${i}`}>
-                  <td><input id={ID_PREFIX + role} type="checkbox" name="role" value={role} disabled={role === 'owner'}/></td>
-                  <td><strong><label htmlFor={ID_PREFIX + role}>{ROLES_INFO[role].label}</label></strong></td>
-                  <td>{ROLES_INFO[role].description}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-
-        <p>
-          <button type="submit" className="major-button" onClick={handleSubmit}>Add user role</button>
-        </p>
-      </form>
     </div>
   );
 };
 
 EditCollaborators.propTypes = {
-  organization: organizationShape,
   organizationCollaborators: organizationCollaboratorsShape,
   organizationOwner: organizationOwnerShape,
+  possibleRoles: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
   removeCollaborator: React.PropTypes.func,
+  rolesInfo: React.PropTypes.objectOf(React.PropTypes.object).isRequired,
   saving: React.PropTypes.string,
   updateCollaborator: React.PropTypes.func,
   user: React.PropTypes.shape({

--- a/src/modules/organizations/components/edit-collaborators.jsx
+++ b/src/modules/organizations/components/edit-collaborators.jsx
@@ -57,6 +57,11 @@ const EditCollaborators = ({ organizationOwner, organizationCollaborators, possi
   );
 };
 
+EditCollaborators.defaultProps = {
+  possibleRoles: {},
+  rolesInfo: {},
+};
+
 EditCollaborators.propTypes = {
   organizationCollaborators: organizationCollaboratorsShape,
   organizationOwner: organizationOwnerShape,

--- a/src/modules/organizations/containers/collaborator-creator-container.jsx
+++ b/src/modules/organizations/containers/collaborator-creator-container.jsx
@@ -23,8 +23,10 @@ class CollaboratorCreatorContainer extends React.Component {
     const anyRolesChecked = Object.keys(this.props.possibleRoles).some((role, i) => {
       return this[ID_PREFIX + role].checked;
     });
+    console.log('calling handleChange', anyRolesChecked)
 
     if (this.userSearch.value() && anyRolesChecked) {
+      console.log('gonna set state')
       this.setState({ disabledSubmit: false });
     }
   }
@@ -50,9 +52,11 @@ class CollaboratorCreatorContainer extends React.Component {
       }
     });
 
-    console.log('users, roles', users, roles)
-    this.setState({ disabledSubmit: true, submitting: false });
-    this.props.addCollaborators();
+    this.props.addCollaborators(roles, users)
+      .then(() => {
+        this.setState({ disabledSubmit: true, submitting: false });
+        this.handleReset();
+      }).catch((error) => { console.error(error); });
   }
 
   render() {

--- a/src/modules/organizations/containers/collaborator-creator-container.jsx
+++ b/src/modules/organizations/containers/collaborator-creator-container.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { UserSearch } from 'zooniverse-react-components';
+
+import FormContainer from '../../common/containers/form-container';
+
+const ID_PREFIX = 'LAB_COLLABORATORS_PAGE_';
+
+class CollaboratorCreatorContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      disabledSubmit: true,
+      submitting: false,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleReset = this.handleReset.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleChange() {
+    const anyRolesChecked = Object.keys(this.props.possibleRoles).some((role, i) => {
+      return this[ID_PREFIX + role].checked;
+    });
+
+    if (this.userSearch.value() && anyRolesChecked) {
+      this.setState({ disabledSubmit: false });
+    }
+  }
+
+  handleReset() {
+    if (this.userSearch.value()) {
+      this.userSearch.clear();
+    }
+
+    Object.keys(this.props.possibleRoles).map((role, i) => {
+      if (this[ID_PREFIX + role].checked) {
+        this[ID_PREFIX + role].checked = false;
+      }
+    });
+  }
+
+  handleSubmit() {
+    this.setState({ submitting: true });
+    const users = this.userSearch.value().map(option => parseInt(option.value));
+    const roles = Object.keys(this.props.possibleRoles).map((role, i) => {
+      if (this[ID_PREFIX + role].checked) {
+        return this[ID_PREFIX + role].value;
+      }
+    });
+
+    console.log('users, roles', users, roles)
+    this.setState({ disabledSubmit: true, submitting: false });
+    this.props.addCollaborators();
+  }
+
+  render() {
+    return (
+      <FormContainer
+        disabledSubmit={this.state.disabledSubmit}
+        onChange={this.handleChange}
+        onReset={this.handleReset}
+        onSubmit={this.handleSubmit}
+        submitting={this.state.submitting}
+        submitLabel="Add user role"
+      >
+        <h3 className="form-label">Add another user role</h3>
+        <fieldset>
+          <UserSearch ref={(input) => { this.userSearch = input; }} />
+        </fieldset>
+
+        <fieldset>
+          <dl>
+            {Object.keys(this.props.possibleRoles).map((role, i) => {
+              return (
+                <span key={ID_PREFIX + role}>
+                  <dt>
+                    <strong><label htmlFor={ID_PREFIX + role}>
+                      <input
+                        ref={(input) => { this[ID_PREFIX + role] = input; }}
+                        id={ID_PREFIX + role}
+                        type="checkbox"
+                        name="role"
+                        value={role}
+                        disabled={role === 'owner'}
+                      />
+                      {this.props.rolesInfo[role].label}
+                    </label></strong>
+                  </dt>
+                  <dd>{this.props.rolesInfo[role].description}</dd>
+                </span>
+              );
+            })}
+          </dl>
+        </fieldset>
+      </FormContainer>
+    );
+  }
+}
+
+CollaboratorCreatorContainer.defaultProps = {
+  addCollaborators: () => {},
+};
+
+CollaboratorCreatorContainer.propTypes = {
+  addCollaborators: React.PropTypes.func.isRequired,
+  possibleRoles: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
+  rolesInfo: React.PropTypes.objectOf(React.PropTypes.object).isRequired,
+};
+
+export default CollaboratorCreatorContainer;

--- a/src/modules/organizations/containers/collaborator-creator-container.jsx
+++ b/src/modules/organizations/containers/collaborator-creator-container.jsx
@@ -23,10 +23,8 @@ class CollaboratorCreatorContainer extends React.Component {
     const anyRolesChecked = Object.keys(this.props.possibleRoles).some((role, i) => {
       return this[ID_PREFIX + role].checked;
     });
-    console.log('calling handleChange', anyRolesChecked)
 
     if (this.userSearch.value() && anyRolesChecked) {
-      console.log('gonna set state')
       this.setState({ disabledSubmit: false });
     }
   }

--- a/src/modules/organizations/containers/collaborators-container.jsx
+++ b/src/modules/organizations/containers/collaborators-container.jsx
@@ -6,6 +6,38 @@ import { organizationShape, organizationCollaboratorsShape, organizationOwnerSha
 import { setOrganizationCollaborators, setOrganizationOwner } from '../action-creators';
 
 import EditCollaborators from '../components/edit-collaborators';
+import CollaboratorCreatorContainer from './collaborator-creator-container';
+
+const POSSIBLE_ROLES = {
+  collaborator: 'admin',
+  // scientist: 'scientist',
+  // moderator: 'moderator',
+  // tester: 'team',
+};
+
+const ROLES_INFO = {
+  collaborator: {
+    label: 'Collaborator',
+    description: 'Collaborators have full access to edit organization content, including deleting the organization.',
+  },
+  // scientist: {
+  //   label: 'Researcher',
+  //   description: 'Members of the research team will be marked as researchers on "Talk"',
+  // },
+  // moderator: {
+  //   label: 'Moderator',
+  //   description: 'Moderators have extra privileges in the community discussion area to moderate discussions. They will also be marked as moderators on "Talk".',
+  // },
+  // tester: {
+  //   label: 'Tester',
+  //   description: 'Testers can view (TODO: view what?). They cannot access the organization builder.',
+  // },
+  // TODO: uncomment when we can translate
+  // translator: {
+  //   label: 'Translator',
+  //   description: 'Translators will have access to the translation site.',
+  // },
+};
 
 class CollaboratorsContainer extends React.Component {
   constructor(props) {
@@ -15,6 +47,7 @@ class CollaboratorsContainer extends React.Component {
       saving: null,
     };
 
+    this.addCollaborators = this.addCollaborators.bind(this);
     this.fetchCollaborators = this.fetchCollaborators.bind(this);
     this.removeCollaborator = this.removeCollaborator.bind(this);
     this.updateCollaborator = this.updateCollaborator.bind(this);
@@ -33,6 +66,10 @@ class CollaboratorsContainer extends React.Component {
   componentWillUnmount() {
     this.props.dispatch(setOrganizationCollaborators(null));
     this.props.dispatch(setOrganizationOwner(null));
+  }
+
+  addCollaborators() {
+    console.log('adding');
   }
 
   removeCollaborator(collaborator) {
@@ -65,7 +102,7 @@ class CollaboratorsContainer extends React.Component {
         // Doing this doesn't maintain the array order, so reordering in UI happens on re-render and can be confusing...
         const updatedCollaborators = this.props.organizationCollaborators.filter(currentCollaborator => !(currentCollaborator === collaborator));
         updatedCollaborators.push(updatedCollaborator);
-        this.props.dispatch(setOrganizationCollaborators(collaborators));
+        this.props.dispatch(setOrganizationCollaborators(updatedCollaborators));
       }).then(() => {
         this.setState({ saving: null });
       }).catch((error) => { console.error(error); });
@@ -98,17 +135,30 @@ class CollaboratorsContainer extends React.Component {
       organization: this.props.organization,
       organizationOwner: this.props.organizationOwner,
       organizationCollaborators: this.props.organizationCollaborators,
+      possibleRoles: POSSIBLE_ROLES,
       removeCollaborator: this.removeCollaborator,
+      rolesInfo: ROLES_INFO,
       saving: this.state.saving,
       updateCollaborator: this.updateCollaborator,
       user: this.props.user,
     };
 
-    return (<EditCollaborators {...props} />);
+    return (
+      <div>
+        <EditCollaborators {...props} />
+        <hr />
+        <CollaboratorCreatorContainer
+          addCollaborators={this.addCollaborators}
+          possibleRoles={POSSIBLE_ROLES}
+          rolesInfo={ROLES_INFO}
+        />
+      </div>
+    );
   }
 }
 
 CollaboratorsContainer.propTypes = {
+  children: React.PropTypes.node,
   dispatch: React.PropTypes.func,
   organization: organizationShape,
   organizationCollaborators: organizationCollaboratorsShape,

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -1,0 +1,3 @@
+.form
+  fieldset
+    border: none

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -1,4 +1,7 @@
 @import "nib"
+@import "../../node_modules/Zooniverse-React-Components/lib/zooniverse-react-components.css"
+@import "../../node_modules/react-select/dist/react-select.css"
+
 @import "global/common"
 @import "global/typography"
 

--- a/test/modules/common/form-container-test.js
+++ b/test/modules/common/form-container-test.js
@@ -13,17 +13,21 @@ describe('FormContainer', function() {
   before(function() {
     onSubmit = sinon.spy();
     onReset = sinon.spy();
+  });
+
+  it('renders children', function() {
     wrapper = shallow(
       <FormContainer onSubmit={onSubmit} onReset={onReset} resetLabel="Reset" submitLabel="Submit">
         <span></span>
       </FormContainer>);
-  });
-
-  it('renders children', function() {
     expect(wrapper.find('span')).to.have.length(1);
   });
 
   describe('change event', function() {
+    before(function() {
+      wrapper = shallow(<FormContainer onSubmit={onSubmit} onReset={onReset} resetLabel="Reset" submitLabel="Submit" />);
+    });
+
     it('does not render the buttons without changes', function() {
       expect(wrapper.find('button')).to.have.length(0);
     });
@@ -34,8 +38,34 @@ describe('FormContainer', function() {
     });
   });
 
-  describe('submit button', function() {
+  describe('submit button render', function() {
     let submitButton;
+    before(function() {
+      wrapper = mount(<FormContainer onSubmit={onSubmit} onReset={onReset} resetLabel="Reset" submitLabel="Submit" />);
+    });
+
+    beforeEach(function() {
+      wrapper.simulate('change');
+      submitButton = wrapper.find('button[type="submit"]');
+    });
+
+    it('uses submitLabel prop when set', function() {
+      expect(submitButton.text()).to.equal('Submit');
+    });
+
+    it('is disabled if disabledSubmit prop is true', function() {
+      expect(submitButton.prop('disabled')).to.be.false;
+      wrapper.setProps({ disabledSubmit: true });
+      expect(submitButton.prop('disabled')).to.be.true;
+    });
+  });
+
+  describe('submit button onSubmit event', function() {
+    let submitButton;
+    before(function() {
+      wrapper = shallow(<FormContainer onSubmit={onSubmit} onReset={onReset} resetLabel="Reset" submitLabel="Submit" />);
+    });
+
     beforeEach(function() {
       wrapper.simulate('change');
       submitButton = wrapper.find('button[type="submit"]');
@@ -47,17 +77,18 @@ describe('FormContainer', function() {
       expect(onSubmit.calledOnce).to.be.true;
     });
 
-    it('sets state to false after clicking submit', function() {
+    it('sets show and submitting state to false after clicking submit', function() {
+      expect(wrapper.state('submitting')).to.be.false;
       expect(wrapper.state('show')).to.be.false;
-    });
-
-    it('uses submitLabel prop when set', function() {
-      expect(submitButton.text()).to.equal('Submit');
     });
   });
 
   describe('reset button', function() {
     let resetButton;
+    before(function() {
+      wrapper = shallow(<FormContainer onSubmit={onSubmit} onReset={onReset} resetLabel="Reset" submitLabel="Submit" />);
+    });
+
     beforeEach(function() {
       wrapper.simulate('change');
       resetButton = wrapper.find('button[type="reset"]');
@@ -68,7 +99,8 @@ describe('FormContainer', function() {
       expect(onReset.calledOnce).to.be.true;
     });
 
-    it('sets state to false after clicking cancel', function() {
+    it('sets show and submitting state to false after clicking cancel', function() {
+      expect(wrapper.state('submitting')).to.be.false;
       expect(wrapper.state('show')).to.be.false;
     });
 

--- a/test/modules/organizations/collaborator-creator-test.js
+++ b/test/modules/organizations/collaborator-creator-test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { UserSearch } from 'zooniverse-react-components';
+
+import CollaboratorCreator from '../../../src/modules/organizations/containers/collaborator-creator-container';
+import FormContainer from '../../../src/modules/common/containers/form-container';
+
+describe('CollaboratorCreator', function() {
+  let wrapper;
+  let addCollaborators;
+
+  const ROLES_INFO = {
+    collaborator: {
+      label: 'Collaborator',
+      description: 'Collaborators have full access to edit organization content, including deleting the organization.',
+    },
+  };
+
+  const POSSIBLE_ROLES = {
+    collaborator: 'admin',
+  };
+
+  before(function() {
+    addCollaborators = sinon.spy();
+    wrapper = mount(<CollaboratorCreator
+      addCollaborators={addCollaborators}
+      possibleRoles={POSSIBLE_ROLES}
+      rolesInfo={ROLES_INFO}
+    />);
+  });
+
+  it('should render a <FormContainer /> component', function() {
+    expect(wrapper.find(FormContainer)).to.have.length(1);
+  });
+
+  it('should render a <UserSearch /> component', function() {
+    expect(wrapper.find(UserSearch)).to.have.length(1);
+  });
+
+  describe('handleChange event', function() {
+    let roleCheckbox;
+    before(function() {
+      roleCheckbox = wrapper.find('#LAB_COLLABORATORS_PAGE_collaborator');
+    });
+
+    it('should not set disabledSubmit state to false if form is partially filled', function() {
+      roleCheckbox.prop('checked', true);
+      wrapper.instance().handleChange();
+      expect(wrapper.state('disabledSubmit')).to.be.true;
+    });
+
+    it('should set disabledSubmit state to false if form is fully filled', function() {
+      roleCheckbox.prop('checked', true);
+      wrapper.instance().userSearch.onChange(['srallen086']);
+      wrapper.instance().handleChange();
+      expect(wrapper.state('disabledSubmit')).to.be.false;
+    });
+
+    afterEach(function() {
+      wrapper.instance().handleReset();
+    });
+  });
+});

--- a/test/modules/organizations/collaborator-creator-test.js
+++ b/test/modules/organizations/collaborator-creator-test.js
@@ -39,27 +39,30 @@ describe('CollaboratorCreator', function() {
     expect(wrapper.find(UserSearch)).to.have.length(1);
   });
 
-  describe('handleChange event', function() {
-    let roleCheckbox;
-    before(function() {
-      roleCheckbox = wrapper.find('#LAB_COLLABORATORS_PAGE_collaborator');
-    });
+  // describe('handleChange event', function() {
+  //   let roleCheckbox;
+  //   before(function() {
+  //     roleCheckbox = wrapper.find('#LAB_COLLABORATORS_PAGE_collaborator');
+  //   });
 
-    it('should not set disabledSubmit state to false if form is partially filled', function() {
-      roleCheckbox.prop('checked', true);
-      wrapper.instance().handleChange();
-      expect(wrapper.state('disabledSubmit')).to.be.true;
-    });
+    // it('should not set disabledSubmit state to false if form is partially filled', function() {
+    //   roleCheckbox.simulate('change', { target: { checked: true } });
+    //   // wrapper.instance().handleChange();
+    //   expect(wrapper.state('disabledSubmit')).to.be.true;
+    // });
 
-    it('should set disabledSubmit state to false if form is fully filled', function() {
-      roleCheckbox.prop('checked', true);
-      wrapper.instance().userSearch.onChange(['srallen086']);
-      wrapper.instance().handleChange();
-      expect(wrapper.state('disabledSubmit')).to.be.false;
-    });
+    // it('should set disabledSubmit state to false if form is fully filled', function() {
+    //   roleCheckbox = wrapper.find('#LAB_COLLABORATORS_PAGE_collaborator').render();
+    //   // roleCheckbox.simulate('change', { target: { checked: true } });
+    //   roleCheckbox.prop('checked', true);
+    //   wrapper.instance().userSearch.onChange(['srallen086']);
+    //   console.log('wrapper', roleCheckbox.prop('checked'), wrapper.state())
+    //   // wrapper.instance().handleChange();
+    //   expect(wrapper.state('disabledSubmit')).to.be.false;
+    // });
 
-    afterEach(function() {
-      wrapper.instance().handleReset();
-    });
+    // afterEach(function() {
+    //   wrapper.instance().handleReset();
+    // });
   });
 });


### PR DESCRIPTION
Still more work to do, just opening so you all can see what I've been doing.

- Adds a collaborator creator container component that tracks some local state related to the form. Also wanted to use refs. `bindInput` and adding constant variables for fields as is being done in the edit-details component just felt like a round about way of tracking state w/o the react lifecycle of the component class. 
- Enhancements for the `FormContainer`.
- Updates webpack to support vanilla css files