### PR TITLE
Update markdownz and add to details editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.2.5",
     "data-uri-to-blob": "^0.0.4",
     "history": "^4.4.1",
-    "markdownz": "^7.0.1",
+    "markdownz": "^7.2.0",
     "panoptes-client": "^2.7.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -13,14 +13,32 @@ class DetailsFormContainer extends React.Component {
 
     this.collectValues = this.collectValues.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.onTextAreaChange = this.onTextAreaChange.bind(this);
     this.resetOrganization = this.resetOrganization.bind(this);
+
+    this.state = {
+      textarea: ''
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ textarea: this.props.organization.introduction });
+  }
+
+  onTextAreaChange(event) {
+    const textarea = event.target.value;
+
+    this.setState({ textarea });
   }
 
   collectValues() {
+    // TODO rework this to better work with the MarkdownEditor
+    // TODO only submit changed fields!
     const result = {};
     Object.keys(this.fields).forEach((fieldName) => {
       result[fieldName] = this.fields[fieldName].value();
     });
+    result.introduction = this.state.textarea;
     return result;
   }
 
@@ -36,6 +54,8 @@ class DetailsFormContainer extends React.Component {
   render() {
     // TODO rename prop in markdownz to be resource not project.
     // TODO extract <MarkdownHelp /> into shared components repo.
+    // TODO extract MarkdownEditor into its own component put into common folder
+    // TODO split into functional component
     const organization = this.props.organization;
     const NameInput = bindInput(organization.display_name, <input type="text" />);
     const DescriptionInput = bindInput(organization.description, <input type="text" />);
@@ -59,6 +79,25 @@ class DetailsFormContainer extends React.Component {
           <small className="form__help">
             This should be a one-line call to action for your organization that displays on your landing page.{' '}
             <CharLimit limit={300} string={this.props.organization.description || ''} />
+          </small>
+        </fieldset>
+        <fieldset className="form__fieldset">
+          <label className="form__label" htmlFor="introduction">
+            Introduction
+            <MarkdownEditor
+              className="form__markdown-editor--full"
+              id="introduction"
+              name="introduction"
+              onChange={this.onTextAreaChange}
+              project={this.props.organization}
+              rows="10"
+              value={this.state.textarea}
+            />
+          </label>
+          <small className="form__help">
+            Add a brief introduction to get people interested in your organization.
+            This will display on your landing page.{' '}
+            <CharLimit limit={1500} string={this.state.textarea || ''} />
           </small>
         </fieldset>
       </FormContainer>

--- a/src/styles/global/markdown-editor.styl
+++ b/src/styles/global/markdown-editor.styl
@@ -1,0 +1,61 @@
+.markdown-editor-input
+  display: block
+  font-family: Courier, monospace
+  position: relative
+  width: 100%
+
+.markdown-editor-preview
+  bottom: 0
+  border: 1px solid rgba(gray, 0.2)
+  left: 0
+  overflow: auto
+  padding: 0 1em 0 0.5em
+  position: absolute
+  right: 0
+  top: 0
+
+  > :first-child
+    margin-top: 0
+
+  > :last-child
+    margin-bottom: 0
+
+.markdown-editor-controls
+  float: right
+
+  button
+    @extends $reset-button
+    padding: 0 0.2em
+
+.markdown-editor
+  &:not([data-previewing])
+    .editor-area
+      position: relative
+
+    .markdown-editor-input
+      opacity: 1
+      z-index: 1
+
+    .markdown-editor-preview
+      opacity: 0
+
+  &[data-previewing]
+    .editor-area
+      position: relative
+
+    .markdown-editor-input
+      opacity: 0
+
+    .markdown-editor-preview
+      opacity: 1
+      z-index: 1
+
+.markdown-editor-help
+  margin: 2em
+  table
+    margin: auto
+    width: 100%
+    border-collapse: collapse
+  td
+    border: 1px solid black
+    padding: 10px

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,9 +4002,9 @@ markdown-it-footnote@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-3.0.1.tgz#7f3730747cacc86e2fe0bf8a17a710f34791517a"
 
-"markdown-it-imsize@git://github.com/edpaget/markdown-it-imsize":
+"markdown-it-imsize@git://github.com/edpaget/markdown-it-imsize.git":
   version "2.0.1"
-  resolved "git://github.com/edpaget/markdown-it-imsize#101510152e42cd8d9c6fc59a5f143accedf19ae9"
+  resolved "git://github.com/edpaget/markdown-it-imsize.git#101510152e42cd8d9c6fc59a5f143accedf19ae9"
 
 markdown-it-sub@~1.0.0:
   version "1.0.0"
@@ -4035,9 +4035,9 @@ markdown-it@~7.0.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.1"
 
-markdownz@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/markdownz/-/markdownz-7.0.1.tgz#225b2dff58616348f2e85d44e2853f0872a46933"
+markdownz@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/markdownz/-/markdownz-7.2.0.tgz#a2945069118e16a3cbf3db3f26b09f30421a29e0"
   dependencies:
     markdown-it "~7.0.1"
     markdown-it-anchor "~2.5.0"
@@ -4049,8 +4049,8 @@ markdownz@^7.0.1:
     markdown-it-sup "~1.0.0"
     markdown-it-table-of-contents "~0.2.2"
     markdown-it-video "~0.4.0"
-    react "~15.3.2"
-    react-dom "~15.3.2"
+    react "~15.4"
+    react-dom "~15.4"
     react-mixin "~1.7.0"
     twemoji "~1.4.1"
 
@@ -5082,17 +5082,13 @@ react-addons-test-utils@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.1.tgz#1e4caab151bf27cce26df5f9cb714f4fd8359ae1"
 
-react-dom@^15.4.1:
+react-dom@^15.4.1, react-dom@~15.4:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.1.tgz#d54c913261aaedb17adc20410d029dcc18a1344a"
   dependencies:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-
-react-dom@~15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
 
 react-input-autosize@^1.1.0:
   version "1.1.0"
@@ -5131,17 +5127,9 @@ react-select@^1.0.0-rc.2, react-select@^1.0.0-rc.3:
     classnames "^2.2.4"
     react-input-autosize "^1.1.0"
 
-react@^15.4.1:
+react@^15.4.1, react@~15.4:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.4.1.tgz#498e918602677a3983cd0fd206dfe700389a0dd6"
-  dependencies:
-    fbjs "^0.8.4"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-
-react@~15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
   dependencies:
     fbjs "^0.8.4"
     loose-envify "^1.1.0"


### PR DESCRIPTION
This is gonna need another refactor pass and I left several TODO comments for that. Otherwise, this is just adding the latest version of markdownz and the introduction field to the details editor. This should merge before the about pages. 