### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:8-onbuild

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+
+services:
+  dev:
+    build:
+      context:  ./
+      dockerfile: Dockerfile
+    environment:
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "redux-devtools-extension": "~1.0.0",
     "redux-logger": "~2.7.4",
     "redux-thunk": "~2.1.0",
-    "zooniverse-react-components": "git+ssh://git@github.com/zooniverse/Zooniverse-React-Components.git#v0.3.0"
+    "zooniverse-react-components": "https://github.com/zooniverse/Zooniverse-React-Components.git#v0.3.0"
   },
   "devDependencies": {
     "babel-cli": "~6.24.0",

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -1,5 +1,5 @@
 @import "nib"
-@import "../../node_modules/Zooniverse-React-Components/lib/zooniverse-react-components.css"
+@import "../../node_modules/zooniverse-react-components/lib/zooniverse-react-components.css"
 @import "../../node_modules/react-select/dist/react-select.css"
 
 @import "global/common"


### PR DESCRIPTION
This will be required for #9, to automate deploys with Jenkins.

Changes Zooniverse-React-Components to use https URI, because using git+ssh would require additional dependencies to be installed.

You should be able to test this with something like the following:

```
docker run -it --rm zooniverse/pfe-lab npm run-script build
```

When I try to do `npm build` here (either in Docker or natively) I get a few `Module not found` errors, which are stopping me from fully testing this myself at the moment, so it'd be good if someone else can test this too.