### PR TITLE
Make org-list avatars square

### DIFF
--- a/src/styles/components/organizations-list.styl
+++ b/src/styles/components/organizations-list.styl
@@ -30,9 +30,9 @@
   &__avatar
     background-position: 50%, 50%
     background-size: cover
-    border-radius: 50%
     flex: 0 0 2.5em
     height: 2.5em
+    width: 2.5em
 
   &__description
     flex: 1 1 auto


### PR DESCRIPTION
Fixes part of #69.

Currently does not crop image, so if user chooses a rectangular image, it gets distorted - moving on to other styling issues, but happy to circle back to this if we want to crop the avatar image so that rectangular images do not get distorted.