### PR TITLE
Add dashboard plugin custom port to cli script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "zooniverse"
   ],
   "scripts": {
-    "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -- babel-node ./server.js",
+    "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3777  -- babel-node ./server.js",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.production.config.js -p",
     "_publish": "publisssh ./dist \"zooniverse-static/$PATH_ROOT/$SUBDIR\"",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.lab-preview.zooniverse.org/\"",


### PR DESCRIPTION
- custom port for dashboard plugin matches the one set in [`webpack config`](https://github.com/zooniverse/pfe-lab/blob/master/webpack.config.js#L35)