### PR TITLE
Add MarkdownHelp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5045,9 +5045,9 @@
       "integrity": "sha1-PkhUjhXaBCbwGeuV+pbzOXuV4BI="
     },
     "markdownz": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.2.1.tgz",
-      "integrity": "sha1-O6QbfbQ+uUc8rTweD/RC4cZB96U="
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.3.0.tgz",
+      "integrity": "sha512-OhW/jbqr8WXRV12KXlLKbTpx42X7dtkmNoHP5QqrcKL+51V3L2wyyvWjMKqzNoGhim3H/EH6/TFJt9ir44pJ/w=="
     },
     "marked": {
       "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "data-uri-to-blob": "~0.0.4",
     "grommet": "^1.4.0",
     "history": "~4.4.1",
-    "markdownz": "~7.2.0",
+    "markdownz": "~7.3.0",
     "panoptes-client": "~2.7.2",
     "react": "~15.4.1",
     "react-dom": "~15.4.1",

--- a/src/modules/common/components/markdown-editor.jsx
+++ b/src/modules/common/components/markdown-editor.jsx
@@ -26,8 +26,8 @@ class MarkdownEditor extends React.Component {
       >
         {<Markdownz.MarkdownHelp
           talk={this.props.talk}
-          title={this.props.title}/
-        >}
+          title={this.props.title}
+        />}
       </Layer>
     );
   }
@@ -48,12 +48,14 @@ class MarkdownEditor extends React.Component {
 
 MarkdownEditor.defaultProps = {
   className: 'form__markdown-editor--full',
-  talk: false
+  talk: false,
+  title: <h1 className="markdown-editor-title">Guide to using Markdown</h1>
 };
 
 MarkdownEditor.propTypes = {
   className: PropTypes.string,
-  talk: PropTypes.bool
+  talk: PropTypes.bool,
+  title: PropTypes.node
 };
 
 export default MarkdownEditor;

--- a/src/modules/common/components/markdown-editor.jsx
+++ b/src/modules/common/components/markdown-editor.jsx
@@ -18,6 +18,11 @@ class MarkdownEditor extends React.Component {
   }
 
   renderMarkdownHelp() {
+    const helpProps = { talk: this.props.helpTalk };
+    if (this.props.helpTitle) {
+      helpProps.title = this.props.helpTitle;
+    }
+
     return (
       <Layer
         closer={true}
@@ -25,8 +30,7 @@ class MarkdownEditor extends React.Component {
         onClose={this.handleClickToggleHelp}
       >
         {<Markdownz.MarkdownHelp
-          talk={this.props.talk}
-          title={this.props.title}
+          {...helpProps}
         />}
       </Layer>
     );
@@ -48,14 +52,13 @@ class MarkdownEditor extends React.Component {
 
 MarkdownEditor.defaultProps = {
   className: 'form__markdown-editor--full',
-  talk: false,
-  title: <h1 className="markdown-editor-title">Guide to using Markdown</h1>
+  helpTalk: false
 };
 
 MarkdownEditor.propTypes = {
   className: PropTypes.string,
-  talk: PropTypes.bool,
-  title: PropTypes.node
+  helpTalk: PropTypes.bool,
+  helpTitle: PropTypes.node
 };
 
 export default MarkdownEditor;

--- a/src/modules/common/components/markdown-editor.jsx
+++ b/src/modules/common/components/markdown-editor.jsx
@@ -24,7 +24,10 @@ class MarkdownEditor extends React.Component {
         flush={true}
         onClose={this.handleClickToggleHelp}
       >
-        {<Markdownz.MarkdownHelp talk={this.props.talk} />}
+        {<Markdownz.MarkdownHelp
+          talk={this.props.talk}
+          title={this.props.title}/
+        >}
       </Layer>
     );
   }

--- a/src/modules/common/components/markdown-editor.jsx
+++ b/src/modules/common/components/markdown-editor.jsx
@@ -1,0 +1,54 @@
+import React, { PropTypes } from 'react';
+import * as Markdownz from 'markdownz';
+import Layer from 'grommet/components/Layer';
+
+class MarkdownEditor extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleClickToggleHelp = this.handleClickToggleHelp.bind(this);
+
+    this.state = {
+      isHelpVisible: false
+    };
+  }
+
+  handleClickToggleHelp() {
+    this.setState({ isHelpVisible: !this.state.isHelpVisible });
+  }
+
+  renderMarkdownHelp() {
+    return (
+      <Layer
+        closer={true}
+        flush={true}
+        onClose={this.handleClickToggleHelp}
+      >
+        {<Markdownz.MarkdownHelp />}
+      </Layer>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {this.state.isHelpVisible && this.renderMarkdownHelp()}
+        <Markdownz.MarkdownEditor
+          {...this.props}
+          onHelp={() => this.handleClickToggleHelp()}
+        />
+      </div>
+    );
+  }
+};
+
+MarkdownEditor.defaultProps = {
+  className: "form__markdown-editor--full"
+}
+
+MarkdownEditor.propTypes = {
+  value: PropTypes.string,
+  className: PropTypes.string
+}
+
+export default MarkdownEditor;

--- a/src/modules/common/components/markdown-editor.jsx
+++ b/src/modules/common/components/markdown-editor.jsx
@@ -24,7 +24,7 @@ class MarkdownEditor extends React.Component {
         flush={true}
         onClose={this.handleClickToggleHelp}
       >
-        {<Markdownz.MarkdownHelp />}
+        {<Markdownz.MarkdownHelp talk={this.props.talk} />}
       </Layer>
     );
   }
@@ -35,20 +35,22 @@ class MarkdownEditor extends React.Component {
         {this.state.isHelpVisible && this.renderMarkdownHelp()}
         <Markdownz.MarkdownEditor
           {...this.props}
+          className={this.props.className}
           onHelp={() => this.handleClickToggleHelp()}
         />
       </div>
     );
   }
-};
+}
 
 MarkdownEditor.defaultProps = {
-  className: "form__markdown-editor--full"
-}
+  className: 'form__markdown-editor--full',
+  talk: false
+};
 
 MarkdownEditor.propTypes = {
-  value: PropTypes.string,
-  className: PropTypes.string
-}
+  className: PropTypes.string,
+  talk: PropTypes.bool
+};
 
 export default MarkdownEditor;

--- a/src/modules/organizations/components/about-page.jsx
+++ b/src/modules/organizations/components/about-page.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MarkdownEditor } from 'markdownz';
+import MarkdownEditor from '../../common/components/markdown-editor';
 
 import FormContainer from '../../common/containers/form-container';
 import { organizationShape, organizationPageShape } from '../model';
@@ -35,7 +35,6 @@ const AboutPage = (props) => {
             <br />
             <MarkdownEditor
               project={props.organization}
-              className="form__markdown-editor--full"
               name="content"
               id="content"
               rows="20"

--- a/src/modules/organizations/components/about-page.jsx
+++ b/src/modules/organizations/components/about-page.jsx
@@ -34,12 +34,12 @@ const AboutPage = (props) => {
             About Page Content
             <br />
             <MarkdownEditor
-              project={props.organization}
-              name="content"
               id="content"
+              name="content"
+              onChange={props.onTextAreaChange}
+              project={props.organization}
               rows="20"
               value={props.pageContent}
-              onChange={props.onTextAreaChange}
             />
           </label>
         </fieldset>

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { MarkdownEditor, MarkdownHelp } from 'markdownz';
+import MarkdownEditor from '../../common/components/markdown-editor';
 import { DisplayNameSlugEditor } from 'zooniverse-react-components';
-import Layer from 'grommet/components/Layer';
 import { organizationShape } from '../model';
 import { setCurrentOrganization } from '../action-creators';
 import bindInput from '../../common/containers/bind-input';
 import FormContainer from '../../common/containers/form-container';
 import CharLimit from '../../common/components/char-limit';
-
 
 class DetailsFormContainer extends React.Component {
   constructor(props) {
@@ -16,13 +14,11 @@ class DetailsFormContainer extends React.Component {
 
     this.collectValues = this.collectValues.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.onTextAreaChange = this.onTextAreaChange.bind(this);
+    this.handleTextAreaChange = this.handleTextAreaChange.bind(this);
     this.resetOrganization = this.resetOrganization.bind(this);
-    this.handleClickToggleHelp = this.handleClickToggleHelp.bind(this);
 
     this.state = {
-      textarea: '',
-      isHelpVisible: false
+      textarea: ''
     };
   }
 
@@ -30,7 +26,7 @@ class DetailsFormContainer extends React.Component {
     this.setState({ textarea: this.props.organization.introduction });
   }
 
-  onTextAreaChange(event) {
+  handleTextAreaChange(event) {
     const textarea = event.target.value;
 
     this.setState({ textarea });
@@ -56,22 +52,6 @@ class DetailsFormContainer extends React.Component {
     this.props.dispatch(setCurrentOrganization(this.props.organization));
   }
 
-  handleClickToggleHelp() {
-    this.setState({ isHelpVisible: !this.state.isHelpVisible });
-  }
-
-  renderMarkdownHelp() {
-    return (
-      <Layer
-        closer={true}
-        flush={true}
-        onClose={this.handleClickToggleHelp}
-      >
-        {<MarkdownHelp />}
-      </Layer>
-    );
-  }
-
   render() {
     // TODO rename prop in markdownz to be resource not project.
     // TODO extract <MarkdownHelp /> into shared components repo.
@@ -83,7 +63,6 @@ class DetailsFormContainer extends React.Component {
 
     return (
       <div>
-        {this.state.isHelpVisible && this.renderMarkdownHelp()}
         <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
           <fieldset className="form__fieldset">
             <DisplayNameSlugEditor
@@ -110,14 +89,12 @@ class DetailsFormContainer extends React.Component {
             <label className="form__label" htmlFor="introduction">
               Introduction
               <MarkdownEditor
-                className="form__markdown-editor--full"
                 id="introduction"
                 name="introduction"
-                onChange={this.onTextAreaChange}
+                onChange={this.handleTextAreaChange}
                 project={this.props.organization}
                 rows="10"
                 value={this.state.textarea}
-                onHelp={() => this.handleClickToggleHelp()}
               />
             </label>
             <small className="form__help">

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import { MarkdownEditor, MarkdownHelp } from 'markdownz';
 import { DisplayNameSlugEditor } from 'zooniverse-react-components';
@@ -19,9 +18,11 @@ class DetailsFormContainer extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.onTextAreaChange = this.onTextAreaChange.bind(this);
     this.resetOrganization = this.resetOrganization.bind(this);
+    this.handleClickToggleHelp = this.handleClickToggleHelp.bind(this);
 
     this.state = {
-      textarea: ''
+      textarea: '',
+      isHelpVisible: false
     };
   }
 
@@ -55,40 +56,20 @@ class DetailsFormContainer extends React.Component {
     this.props.dispatch(setCurrentOrganization(this.props.organization));
   }
 
-  alert(message) {
-    const defer = {
-      resolve: null,
-      reject: null
-    };
+  handleClickToggleHelp() {
+    this.setState({ isHelpVisible: !this.state.isHelpVisible });
+  }
 
-    const promise = new Promise((resolve, reject) => {
-      defer.resolve = resolve;
-      defer.reject = reject;
-    });
-
-    if (typeof message === 'function') {
-      var message = message(defer.resolve, defer.reject);
-    }
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
-    ReactDOM.render(
+  renderMarkdownHelp() {
+    return (
       <Layer
         closer={true}
         flush={true}
-        onClose={defer.resolve}
+        onClose={this.handleClickToggleHelp}
       >
-        {message}
-      </Layer>, container
+        {<MarkdownHelp />}
+      </Layer>
     );
-
-    promise.then(() => {
-      ReactDOM.unmountComponentAtNode(container);
-      return container.parentNode.removeChild(container);
-    });
-
-    return promise;
   }
 
   render() {
@@ -101,52 +82,59 @@ class DetailsFormContainer extends React.Component {
     this.fields = {};
 
     return (
-      <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
-        <fieldset className="form__fieldset">
-          <DisplayNameSlugEditor
-            resource={organization}
-            resourceType="organization"
-            ref={(node) => { this.fields.display_name = node; }}
-          />
-        </fieldset>
-        <fieldset className="form__fieldset">
-          <label className="form__label" htmlFor="description">
-            Description
-            <DescriptionInput
-              className="form__input form__input--full-width"
-              id="description"
-              ref={(node) => { this.fields.description = node; }}
+      <div>
+        {this.state.isHelpVisible && this.renderMarkdownHelp()}
+        <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
+          <fieldset className="form__fieldset">
+            <DisplayNameSlugEditor
+              resource={organization}
+              resourceType="organization"
+              ref={(node) => { this.fields.display_name = node; }}
             />
-          </label>
-          <small className="form__help">
-            This should be a one-line call to action for your organization that displays on your landing page.{' '}
-            <CharLimit limit={300} string={this.props.organization.description || ''} />
-          </small>
-        </fieldset>
-        <fieldset className="form__fieldset">
-          <label className="form__label" htmlFor="introduction">
-            Introduction
-            <MarkdownEditor
-              className="form__markdown-editor--full"
-              id="introduction"
-              name="introduction"
-              onChange={this.onTextAreaChange}
-              project={this.props.organization}
-              rows="10"
-              value={this.state.textarea}
-              onHelp={() => this.alert(MarkdownHelp)}
-            />
-          </label>
-          <small className="form__help">
-            Add a brief introduction to get people interested in your organization.
-            This will display on your landing page.{' '}
-            <CharLimit limit={1500} string={this.state.textarea || ''} />
-          </small>
-        </fieldset>
-      </FormContainer>
+          </fieldset>
+          <fieldset className="form__fieldset">
+            <label className="form__label" htmlFor="description">
+              Description
+              <DescriptionInput
+                className="form__input form__input--full-width"
+                id="description"
+                ref={(node) => { this.fields.description = node; }}
+              />
+            </label>
+            <small className="form__help">
+              This should be a one-line call to action for your organization that displays on your landing page.{' '}
+              <CharLimit limit={300} string={this.props.organization.description || ''} />
+            </small>
+          </fieldset>
+          <fieldset className="form__fieldset">
+            <label className="form__label" htmlFor="introduction">
+              Introduction
+              <MarkdownEditor
+                className="form__markdown-editor--full"
+                id="introduction"
+                name="introduction"
+                onChange={this.onTextAreaChange}
+                project={this.props.organization}
+                rows="10"
+                value={this.state.textarea}
+                onHelp={() => this.handleClickToggleHelp()}
+              />
+            </label>
+            <small className="form__help">
+              Add a brief introduction to get people interested in your organization.
+              This will display on your landing page.{' '}
+              <CharLimit limit={1500} string={this.state.textarea || ''} />
+            </small>
+          </fieldset>
+        </FormContainer>
+      </div>
     );
   }
 }
+
+DetailsFormContainer.defaultProps = {
+  organization: {},
+};
 
 DetailsFormContainer.propTypes = {
   dispatch: React.PropTypes.func,

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { MarkdownEditor } from 'markdownz';
+import { MarkdownEditor, MarkdownHelp } from 'markdownz';
 import { DisplayNameSlugEditor } from 'zooniverse-react-components';
+import Layer from 'grommet/components/Layer';
 import { organizationShape } from '../model';
 import { setCurrentOrganization } from '../action-creators';
 import bindInput from '../../common/containers/bind-input';
 import FormContainer from '../../common/containers/form-container';
 import CharLimit from '../../common/components/char-limit';
+
 
 class DetailsFormContainer extends React.Component {
   constructor(props) {
@@ -52,6 +55,42 @@ class DetailsFormContainer extends React.Component {
     this.props.dispatch(setCurrentOrganization(this.props.organization));
   }
 
+  alert(message) {
+    const defer = {
+      resolve: null,
+      reject: null
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      defer.resolve = resolve;
+      defer.reject = reject;
+    });
+
+    if (typeof message === 'function') {
+      var message = message(defer.resolve, defer.reject);
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    ReactDOM.render(
+      <Layer
+        closer={true}
+        flush={true}
+        onClose={defer.resolve}
+      >
+        {message}
+      </Layer>, container
+    );
+
+    promise.then(() => {
+      ReactDOM.unmountComponentAtNode(container);
+      return container.parentNode.removeChild(container);
+    });
+
+    return promise;
+  }
+
   render() {
     // TODO rename prop in markdownz to be resource not project.
     // TODO extract <MarkdownHelp /> into shared components repo.
@@ -95,6 +134,7 @@ class DetailsFormContainer extends React.Component {
               project={this.props.organization}
               rows="10"
               value={this.state.textarea}
+              onHelp={() => this.alert(MarkdownHelp)}
             />
           </label>
           <small className="form__help">


### PR DESCRIPTION
## PR overview
- Resolves [Issues 87](https://github.com/zooniverse/pfe-lab/issues/87) and [88](https://github.com/zooniverse/pfe-lab/issues/88)
- Updates Markdownz dependency to 7.3.0
- Creates a common MarkdownEditor component that can be imported throughout PFE-lab
- MarkdownHelp modal (displayed via Grommet Layer) is toggled via click handler
- Updates DetailsFormContainer and AboutPage to display common MarkdownEditor and Help

See [Markdownz Issue 57](https://github.com/zooniverse/markdownz/issues/57) for related work.

## Known Issue
- `defaultProps` in MarkdownEditor is currently defining `title` and `talk` with the same values that are given as defaultProps in the Markdownz repo. This duplication feels problematic, but @mcbouslog and I talked it over and decided to open the PR as is - suggestions for improving this duplication are welcome and appreciated :) 