### PR TITLE
Update organization-details instructions

### DIFF
--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -57,6 +57,10 @@ const EditDetails = (props) => {
               {props.organization.listed ? Date(props.organization.listed_at) : 'N/A'}
             </span>
           </div>
+          <small>
+            Status indicates whether an organization is publicly visible (TRUE) or not publicly visible (FALSE).
+            Please contact the Zooniverse team via Talk (use @team or @admin) to change the status of an organization.
+          </small>
           <hr />
           <button
             type="button"

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import MarkdownEditor from '../../common/components/markdown-editor';
 import { DisplayNameSlugEditor } from 'zooniverse-react-components';
+import MarkdownEditor from '../../common/components/markdown-editor';
 import { organizationShape } from '../model';
 import { setCurrentOrganization } from '../action-creators';
 import bindInput from '../../common/containers/bind-input';
@@ -81,7 +81,8 @@ class DetailsFormContainer extends React.Component {
               />
             </label>
             <small className="form__help">
-              This should be a one-line call to action for your organization that displays on your landing page.{' '}
+              This should be a one-line call to action for your organization that displays on your landing page.
+              It will be displayed below the organization&apos;s name.{' '}
               <CharLimit limit={300} string={this.props.organization.description || ''} />
             </small>
           </fieldset>


### PR DESCRIPTION
## PR Overview
- Updates instructions on the `Edit Organization Details` page. Specifically:
  - Organization Description updated to indicate where it is displayed on page (below org name).
  - Organization Status given explanatory text.
- Towards #109.
- Staged [here](https://update-org-details-instructions.lab-preview.zooniverse.org/organizations/14).