### PR TITLE
Prop types update

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "markdownz": "~7.3.0",
     "mock-local-storage": "~1.0.4",
     "panoptes-client": "~2.7.2",
+    "prop-types": "~15.5.10",
     "react": "~15.4.1",
     "react-dom": "~15.4.1",
     "react-redux": "~4.4.6",

--- a/src/modules/common/containers/App.jsx
+++ b/src/modules/common/containers/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Layout from '../components/layout';
 
 /*
@@ -21,7 +22,7 @@ const App = (props) => {
 };
 
 App.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 App.defaultProps = {

--- a/src/modules/common/containers/admin-container.jsx
+++ b/src/modules/common/containers/admin-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { AdminCheckbox } from 'zooniverse-react-components';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -62,12 +63,12 @@ AdminContainer.defaultProps = {
 };
 
 AdminContainer.propTypes = {
-  adminMode: React.PropTypes.bool,
-  dispatch: React.PropTypes.func,
-  loginInitialized: React.PropTypes.bool,
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    admin: React.PropTypes.bool,
+  adminMode: PropTypes.bool,
+  dispatch: PropTypes.func,
+  loginInitialized: PropTypes.bool,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    admin: PropTypes.bool,
   }),
 };
 

--- a/src/modules/common/containers/bind-input.jsx
+++ b/src/modules/common/containers/bind-input.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function bindInput(changeableValue, ComposedComponent) {
   class BoundInput extends React.Component {
@@ -51,7 +52,7 @@ function bindInput(changeableValue, ComposedComponent) {
   }
 
   BoundInput.propTypes = {
-    type: React.PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
   };
 
   BoundInput.defaultProps = {

--- a/src/modules/common/containers/form-container.jsx
+++ b/src/modules/common/containers/form-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class FormContainer extends React.Component {
   constructor(props) {
@@ -72,11 +73,11 @@ FormContainer.defaultProps = {
 };
 
 FormContainer.propTypes = {
-  children: React.PropTypes.node,
-  disabledSubmit: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  onReset: React.PropTypes.func.isRequired,
-  onSubmit: React.PropTypes.func.isRequired,
-  resetLabel: React.PropTypes.string,
-  submitLabel: React.PropTypes.string,
+  children: PropTypes.node,
+  disabledSubmit: PropTypes.bool,
+  onChange: PropTypes.func,
+  onReset: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  resetLabel: PropTypes.string,
+  submitLabel: PropTypes.string,
 };

--- a/src/modules/common/containers/header-auth.jsx
+++ b/src/modules/common/containers/header-auth.jsx
@@ -2,6 +2,7 @@
 // components. Stores state in Redux.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { checkLoginUser, loginToPanoptes, logoutFromPanoptes } from '../../../services/panoptes';
 
@@ -32,9 +33,11 @@ class HeaderAuth extends React.Component {
 }
 
 HeaderAuth.propTypes = {
-  user: React.PropTypes.shape({ login: React.PropTypes.string }),
-  initialized: React.PropTypes.bool,
-  dispatch: React.PropTypes.func,
+  user: PropTypes.shape({
+    login: PropTypes.string
+  }),
+  initialized: PropTypes.bool,
+  dispatch: PropTypes.func,
 };
 
 HeaderAuth.defaultProps = {

--- a/src/modules/common/containers/image-selector.jsx
+++ b/src/modules/common/containers/image-selector.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Thumbnail, FileButton } from 'zooniverse-react-components';
 import toBlob from 'data-uri-to-blob';
 
@@ -128,18 +129,18 @@ class ImageSelector extends React.Component {
 }
 
 ImageSelector.propTypes = {
-  allowDelete: React.PropTypes.bool,
-  baseExpansion: React.PropTypes.number,
-  deleting: React.PropTypes.bool,
-  label: React.PropTypes.string,
-  minArea: React.PropTypes.number,
-  maxSize: React.PropTypes.number,
-  onChange: React.PropTypes.func.isRequired,
-  onDelete: React.PropTypes.func,
-  ratio: React.PropTypes.number,
-  reductionPerPass: React.PropTypes.number,
-  resourceSrc: React.PropTypes.string.isRequired,
-  resourceType: React.PropTypes.string
+  allowDelete: PropTypes.bool,
+  baseExpansion: PropTypes.number,
+  deleting: PropTypes.bool,
+  label: PropTypes.string,
+  minArea: PropTypes.number,
+  maxSize: PropTypes.number,
+  onChange: PropTypes.func.isRequired,
+  onDelete: PropTypes.func,
+  ratio: PropTypes.number,
+  reductionPerPass: PropTypes.number,
+  resourceSrc: PropTypes.string.isRequired,
+  resourceType: PropTypes.string
 };
 
 ImageSelector.defaultProps = {


### PR DESCRIPTION
## PR Overview
- Install `prop-types` package (~15.5.10) to avoid [deprecation warnings](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) included in React 15.5.
- Update prop types in `common/containers` to use `prop-types` package.
  - Conversion to `prop-types` package will be done incrementally, to lessen the potential for merge conflicts with other outstanding PRs.
- Towards #102.
