### PR TITLE
Prop types update - common/components

### DIFF
--- a/src/modules/common/components/char-limit.jsx
+++ b/src/modules/common/components/char-limit.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const CharLimit = ({ limit, string }) => {
   const remaining = limit - string.length;

--- a/src/modules/common/components/landing.jsx
+++ b/src/modules/common/components/landing.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { ZooniverseLogotype } from 'zooniverse-react-components';
 import { loginToPanoptes } from '../../../services/panoptes';
@@ -56,7 +57,7 @@ const Landing = ({ userBoolean }) =>
   </div>;
 
 Landing.propTypes = {
-  userBoolean: React.PropTypes.bool,
+  userBoolean: PropTypes.bool,
 };
 
 Landing.defaultProps = {

--- a/src/modules/common/components/layout.jsx
+++ b/src/modules/common/components/layout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Notification from 'grommet/components/Notification';
 import { ZooFooter } from 'zooniverse-react-components';
@@ -31,15 +32,15 @@ const Layout = props =>
   </div>;
 
 Layout.propTypes = {
-  adminMode: React.PropTypes.bool,
-  appNotification: React.PropTypes.shape({
-    message: React.PropTypes.string,
-    status: React.PropTypes.string
+  adminMode: PropTypes.bool,
+  appNotification: PropTypes.shape({
+    message: PropTypes.string,
+    status: PropTypes.string
   }),
-  children: React.PropTypes.node,
-  dispatch: React.PropTypes.func,
-  loginInitialized: React.PropTypes.bool,
-  user: React.PropTypes.shape({ id: React.PropTypes.string }),
+  children: PropTypes.node,
+  dispatch: PropTypes.func,
+  loginInitialized: PropTypes.bool,
+  user: PropTypes.shape({ id: PropTypes.string }),
 };
 
 Layout.defaultProps = {

--- a/src/modules/common/components/login-button.jsx
+++ b/src/modules/common/components/login-button.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 
 const LoginButton = ({ login }) =>
   <button type="submit" onClick={login}>Login</button>;
 
 LoginButton.propTypes = {
-  login: React.PropTypes.func.isRequired,
+  login: PropTypes.func.isRequired,
 };
 
 export default LoginButton;

--- a/src/modules/common/components/logout-button.jsx
+++ b/src/modules/common/components/logout-button.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-const PropTypes = React.PropTypes;
+import PropTypes from 'prop-types';
 
 const LogoutButton = ({ logout, user }) =>
   <div className="logout-button">

--- a/src/modules/common/components/markdown-editor.jsx
+++ b/src/modules/common/components/markdown-editor.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import * as Markdownz from 'markdownz';
 import Layer from 'grommet/components/Layer';
 

--- a/src/modules/common/components/project-search.jsx
+++ b/src/modules/common/components/project-search.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
 import apiClient from 'panoptes-client/lib/api-client';
 
@@ -38,9 +39,9 @@ const ProjectSearch = ({ clearable, onChange, value }) => {
 };
 
 ProjectSearch.propTypes = {
-  clearable: React.PropTypes.bool,
-  onChange: React.PropTypes.func.isRequired,
-  value: React.PropTypes.string.isRequired,
+  clearable: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
 };
 
 export default ProjectSearch;


### PR DESCRIPTION
## PR Overview
- Update prop types in `common/components` to use `prop-types` package to avoid [deprecation warnings](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) included in React 15.5.
  - Conversion to `prop-types` package will be done incrementally, to lessen the potential for merge conflicts with other outstanding PRs.
- Towards #102.
