### PR TITLE
Prop types update - org/containers

### DIFF
--- a/src/modules/organizations/containers/about-container.jsx
+++ b/src/modules/organizations/containers/about-container.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import apiClient from 'panoptes-client/lib/api-client';
 
@@ -115,7 +116,7 @@ export class AboutContainer extends React.Component {
 }
 
 AboutContainer.propTypes = {
-  dispatch: React.PropTypes.func,
+  dispatch: PropTypes.func,
   organization: organizationShape,
   organizationPage: organizationPageShape,
 };

--- a/src/modules/organizations/containers/collaborator-creator-container.jsx
+++ b/src/modules/organizations/containers/collaborator-creator-container.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { UserSearch } from 'zooniverse-react-components';
 
 import FormContainer from '../../common/containers/form-container';
-
 import notificationHandler from '../../../lib/notificationHandler';
 
 const ID_PREFIX = 'LAB_COLLABORATORS_PAGE_';
@@ -113,10 +113,10 @@ CollaboratorCreatorContainer.defaultProps = {
 };
 
 CollaboratorCreatorContainer.propTypes = {
-  addCollaborators: React.PropTypes.func.isRequired,
-  dispatch: React.PropTypes.func,
-  possibleRoles: React.PropTypes.objectOf(React.PropTypes.string).isRequired,
-  rolesInfo: React.PropTypes.objectOf(React.PropTypes.object).isRequired,
+  addCollaborators: PropTypes.func.isRequired,
+  dispatch: PropTypes.func,
+  possibleRoles: PropTypes.objectOf(PropTypes.string).isRequired,
+  rolesInfo: PropTypes.objectOf(PropTypes.object).isRequired,
 };
 
 export default CollaboratorCreatorContainer;

--- a/src/modules/organizations/containers/collaborators-container.jsx
+++ b/src/modules/organizations/containers/collaborators-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Paginator } from 'zooniverse-react-components';
 
@@ -238,20 +239,20 @@ CollaboratorsContainer.defaultProps = {
 };
 
 CollaboratorsContainer.propTypes = {
-  dispatch: React.PropTypes.func,
-  location: React.PropTypes.shape({
-    query: React.PropTypes.shape({
-      page: React.PropTypes.string,
+  dispatch: PropTypes.func,
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      page: PropTypes.string,
     }),
   }),
   organization: organizationShape,
   organizationCollaborators: organizationCollaboratorsShape,
   organizationOwner: organizationOwnerShape,
-  router: React.PropTypes.shape({
-    push: React.PropTypes.func
+  router: PropTypes.shape({
+    push: PropTypes.func
   }),
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string,
+  user: PropTypes.shape({
+    id: PropTypes.string,
   }),
 };
 

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { DisplayNameSlugEditor } from 'zooniverse-react-components';
 import MarkdownEditor from '../../common/components/markdown-editor';
@@ -115,7 +116,7 @@ DetailsFormContainer.defaultProps = {
 };
 
 DetailsFormContainer.propTypes = {
-  dispatch: React.PropTypes.func,
+  dispatch: PropTypes.func,
   organization: organizationShape,
   updateOrganization: React.PropTypes.func
 };

--- a/src/modules/organizations/containers/edit-details-container.jsx
+++ b/src/modules/organizations/containers/edit-details-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import apiClient from 'panoptes-client/lib/api-client';
@@ -119,13 +120,13 @@ class EditDetailsContainer extends React.Component {
 }
 
 EditDetailsContainer.propTypes = {
-  deleteOrganization: React.PropTypes.func.isRequired,
-  deletionInProgress: React.PropTypes.bool,
-  dispatch: React.PropTypes.func,
+  deleteOrganization: PropTypes.func.isRequired,
+  deletionInProgress: PropTypes.bool,
+  dispatch: PropTypes.func,
   organization: organizationShape,
   organizationAvatar: organizationAvatarShape,
   organizationBackground: organizationBackgroundShape,
-  updateOrganization: React.PropTypes.func.isRequired
+  updateOrganization: PropTypes.func.isRequired
 };
 
 EditDetailsContainer.defaultProps = {

--- a/src/modules/organizations/containers/organization-container.jsx
+++ b/src/modules/organizations/containers/organization-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import apiClient from 'panoptes-client/lib/api-client';
@@ -106,11 +107,11 @@ class OrganizationContainer extends React.Component {
 }
 
 OrganizationContainer.propTypes = {
-  dispatch: React.PropTypes.func,
+  dispatch: PropTypes.func,
   organization: organizationShape,
-  params: React.PropTypes.shape({ id: React.PropTypes.string }),
-  router: React.PropTypes.shape({
-    push: React.PropTypes.func
+  params: PropTypes.shape({ id: PropTypes.string }),
+  router: PropTypes.shape({
+    push: PropTypes.func
   })
 };
 

--- a/src/modules/organizations/containers/organizations-list-container.jsx
+++ b/src/modules/organizations/containers/organizations-list-container.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import apiClient from 'panoptes-client/lib/api-client';
 import counterpart from 'counterpart';
@@ -97,12 +98,12 @@ class OrganizationsListContainer extends React.Component {
 }
 
 OrganizationsListContainer.propTypes = {
-  dispatch: React.PropTypes.func,
+  dispatch: PropTypes.func,
   collaboratedOrganizations: organizationsShape,
   organizationsAvatars: organizationsAvatarsShape,
   ownedOrganizations: organizationsShape,
-  router: React.PropTypes.shape({
-    push: React.PropTypes.func
+  router: PropTypes.shape({
+    push: PropTypes.func
   })
 };
 

--- a/src/modules/organizations/model.js
+++ b/src/modules/organizations/model.js
@@ -1,37 +1,38 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export const organizationShape = React.PropTypes.shape({
-  id: React.PropTypes.string,
-  display_name: React.PropTypes.string,
-  description: React.PropTypes.string,
-  introduction: React.PropTypes.string
+export const organizationShape = PropTypes.shape({
+  id: PropTypes.string,
+  display_name: PropTypes.string,
+  description: PropTypes.string,
+  introduction: PropTypes.string
 });
 
-export const organizationsShape = React.PropTypes.arrayOf(organizationShape);
+export const organizationsShape = PropTypes.arrayOf(organizationShape);
 
-export const organizationCollaboratorsShape = React.PropTypes.arrayOf(
-  React.PropTypes.shape({
-    id: React.PropTypes.string,
-    roles: React.PropTypes.arrayOf(React.PropTypes.string),
+export const organizationCollaboratorsShape = PropTypes.arrayOf(
+  PropTypes.shape({
+    id: PropTypes.string,
+    roles: PropTypes.arrayOf(PropTypes.string),
   }),
 );
 
-export const organizationOwnerShape = React.PropTypes.shape({
-  display_name: React.PropTypes.string,
-  id: React.PropTypes.string,
+export const organizationOwnerShape = PropTypes.shape({
+  display_name: PropTypes.string,
+  id: PropTypes.string,
 });
 
-export const organizationAvatarShape = React.PropTypes.shape({
-  src: React.PropTypes.string
+export const organizationAvatarShape = PropTypes.shape({
+  src: PropTypes.string
 });
 
-export const organizationsAvatarsShape = React.PropTypes.arrayOf(organizationAvatarShape);
+export const organizationsAvatarsShape = PropTypes.arrayOf(organizationAvatarShape);
 
-export const organizationBackgroundShape = React.PropTypes.shape({
-  src: React.PropTypes.string
+export const organizationBackgroundShape = PropTypes.shape({
+  src: PropTypes.string
 });
 
-export const organizationPageShape = React.PropTypes.shape({
-  id: React.PropTypes.string,
-  url_key: React.PropTypes.string,
+export const organizationPageShape = PropTypes.shape({
+  id: PropTypes.string,
+  url_key: PropTypes.string,
 });


### PR DESCRIPTION
## PR Overview
- Update prop types in `organizations/containers` files to use `prop-types` package to avoid [deprecation warnings](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) included in React 15.5.
- Includes update to prop types in `organizations/model`.
- Towards #102.
