### PR TITLE
add external and social urls UI - the sequel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,6 +1907,11 @@
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "dev": true
     },
+    "drag-reorderable": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/drag-reorderable/-/drag-reorderable-0.1.0.tgz",
+      "integrity": "sha1-eL90n/wnErC/0McXKqJic/lm48M="
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "classnames": "~2.2.5",
     "counterpart": "~0.18.0",
     "data-uri-to-blob": "~0.0.4",
+    "drag-reorderable": "~0.1.0",
     "grommet": "^1.4.0",
     "history": "~4.4.1",
     "markdownz": "~7.3.0",

--- a/src/lib/social-icons.js
+++ b/src/lib/social-icons.js
@@ -1,0 +1,17 @@
+const SOCIAL_ICONS = {
+  'bitbucket.com/': 'bitbucket',
+  'facebook.com/': 'facebook-square',
+  'github.com/': 'github',
+  'pinterest.com/': 'pinterest',
+  'plus.google.com/': 'google-plus',
+  'reddit.com/': 'reddit',
+  'tumblr.com/': 'tumblr',
+  'twitter.com/': 'twitter',
+  'weibo.com/': 'weibo',
+  'wordpress.com/': 'wordpress',
+  'youtube.com/': 'youtube',
+  'instagram.com/': 'instagram',
+  'medium.com/': 'medium'
+};
+
+export default SOCIAL_ICONS;

--- a/src/modules/common/components/external-links-editor.jsx
+++ b/src/modules/common/components/external-links-editor.jsx
@@ -36,10 +36,20 @@ export default class ExternalLinksEditor extends React.Component {
     this.props.onChange(urls);
   }
 
-  // TODO handleRemoveLink
+  handleRemoveLink(linkToRemove) {
+    const urlList = this.props.urls.slice();
+    const indexToRemove = urlList.findIndex(i => (i._key === linkToRemove._key));
+    if (indexToRemove > -1) {
+      urlList.splice(indexToRemove, 1);
+      const changes = {
+        urls: urlList
+      };
+    }
+    this.props.onChange(urlList);
+  }
 
   renderRow(link) {
-    // Find the links current position in the list
+    // Find the link's current position in the list
     const idx = this.props.urls.findIndex(i => (i._key === link._key));
     return (
       <tr key={link._key}>
@@ -61,7 +71,7 @@ export default class ExternalLinksEditor extends React.Component {
         </td>
         <td>
           <button type="button">
-            <i className="fa fa-remove" />
+            <i className="fa fa-remove" onClick={this.handleRemoveLink.bind(this, link)} />
           </button>
         </td>
       </tr>

--- a/src/modules/common/components/external-links-editor.jsx
+++ b/src/modules/common/components/external-links-editor.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import DragReorderable from 'drag-reorderable';
 
-// TODO refactor as stateless component
-
 export default class ExternalLinksEditor extends React.Component {
   constructor(props) {
     super(props);
@@ -10,6 +8,7 @@ export default class ExternalLinksEditor extends React.Component {
     this.handleAddLink = this.handleAddLink.bind(this);
     this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleRemoveLink = this.handleRemoveLink.bind(this);
     this.renderRow = this.renderRow.bind(this);
     this.renderTable = this.renderTable.bind(this);
   }
@@ -37,22 +36,18 @@ export default class ExternalLinksEditor extends React.Component {
   }
 
   handleRemoveLink(linkToRemove) {
-    const urlList = this.props.urls.slice();
-    const indexToRemove = urlList.findIndex(i => (i._key === linkToRemove._key));
+    const urls = this.props.urls;
+    const indexToRemove = urls.findIndex(i => (i.key === linkToRemove.key));
     if (indexToRemove > -1) {
-      urlList.splice(indexToRemove, 1);
-      const changes = {
-        urls: urlList
-      };
+      urls.splice(indexToRemove, 1);
     }
-    this.props.onChange(urlList);
+    this.props.onChange(urls);
   }
 
   renderRow(link) {
-    // Find the link's current position in the list
-    const idx = this.props.urls.findIndex(i => (i._key === link._key));
+    const idx = this.props.urls.findIndex(i => (i.key === link.key));
     return (
-      <tr key={link._key}>
+      <tr key={link.key}>
         <td>
           <input
             type="text"
@@ -70,8 +65,8 @@ export default class ExternalLinksEditor extends React.Component {
           />
         </td>
         <td>
-          <button type="button">
-            <i className="fa fa-remove" onClick={this.handleRemoveLink.bind(this, link)} />
+          <button onClick={this.handleRemoveLink.bind(this, link)} type="button">
+            <i className="fa fa-remove" />
           </button>
         </td>
       </tr>
@@ -79,12 +74,16 @@ export default class ExternalLinksEditor extends React.Component {
   }
 
   renderTable(urls) {
-    const tableUrls = urls.filter(url => !url.path);
-    for (const link of tableUrls) {
-      if (!link._key) {
-        link._key = Math.random();
-      }
-    }
+    const tableUrls = urls
+      .filter(url => !url.path)
+      .map((url) => {
+        if (!url.key) {
+          const newUrl = url;
+          newUrl.key = Math.random();
+          return newUrl;
+        }
+        return url;
+      });
 
     return (
       <table className="external-links-table">
@@ -123,5 +122,8 @@ ExternalLinksEditor.defaultProps = {
 
 ExternalLinksEditor.propTypes = {
   onChange: React.PropTypes.func,
-  urls: React.PropTypes.array
+  urls: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      url: React.PropTypes.string
+    }))
 };

--- a/src/modules/common/components/external-links-editor.jsx
+++ b/src/modules/common/components/external-links-editor.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import DragReorderable from 'drag-reorderable';
+
+// TODO refactor as stateless component
+
+export default class ExternalLinksEditor extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleAddLink = this.handleAddLink.bind(this);
+    this.handleLinkReorder = this.handleLinkReorder.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.renderRow = this.renderRow.bind(this);
+    this.renderTable = this.renderTable.bind(this);
+  }
+
+  handleAddLink() {
+    const newUrl = {
+      label: 'Example',
+      url: 'https://example.com/'
+    };
+    const urls = this.props.urls;
+    urls.push(newUrl);
+    this.props.onChange(urls);
+  }
+
+  handleLinkReorder(newLinkOrder) {
+    const socialUrls = this.props.urls.filter(url => url.path);
+    const urls = newLinkOrder.concat(socialUrls);
+    this.props.onChange(urls);
+  }
+
+  handleInputChange(idx, event) {
+    const urls = this.props.urls;
+    urls[idx][event.target.name] = event.target.value;
+    this.props.onChange(urls);
+  }
+
+  // TODO handleRemoveLink
+
+  renderRow(link) {
+    // Find the links current position in the list
+    const idx = this.props.urls.findIndex(i => (i._key === link._key));
+    return (
+      <tr key={link._key}>
+        <td>
+          <input
+            type="text"
+            name="label"
+            value={link.label}
+            onChange={this.handleInputChange.bind(this, idx)}
+          />
+        </td>
+        <td>
+          <input
+            type="text"
+            name="url"
+            value={link.url}
+            onChange={this.handleInputChange.bind(this, idx)}
+          />
+        </td>
+        <td>
+          <button type="button">
+            <i className="fa fa-remove" />
+          </button>
+        </td>
+      </tr>
+    );
+  }
+
+  renderTable(urls) {
+    const tableUrls = urls.filter(url => !url.path);
+    for (const link of tableUrls) {
+      if (!link._key) {
+        link._key = Math.random();
+      }
+    }
+
+    return (
+      <table className="external-links-table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>URL</th>
+          </tr>
+        </thead>
+        <DragReorderable
+          tag="tbody"
+          items={tableUrls}
+          render={this.renderRow}
+          onChange={this.handleLinkReorder}
+        />
+      </table>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {(this.props.urls.length > 0)
+          ? this.renderTable(this.props.urls)
+          : null}
+
+        <button type="button" onClick={this.handleAddLink}>Add a link</button>
+      </div>
+    );
+  }
+}
+
+ExternalLinksEditor.defaultProps = {
+  urls: []
+};
+
+ExternalLinksEditor.propTypes = {
+  onChange: React.PropTypes.func,
+  urls: React.PropTypes.array
+};

--- a/src/modules/common/components/external-links-editor.jsx
+++ b/src/modules/common/components/external-links-editor.jsx
@@ -6,8 +6,8 @@ export default class ExternalLinksEditor extends React.Component {
     super(props);
 
     this.handleAddLink = this.handleAddLink.bind(this);
-    this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleRemoveLink = this.handleRemoveLink.bind(this);
     this.renderRow = this.renderRow.bind(this);
     this.renderTable = this.renderTable.bind(this);
@@ -23,15 +23,15 @@ export default class ExternalLinksEditor extends React.Component {
     this.props.onChange(urls);
   }
 
-  handleLinkReorder(newLinkOrder) {
-    const socialUrls = this.props.urls.filter(url => url.path);
-    const urls = newLinkOrder.concat(socialUrls);
-    this.props.onChange(urls);
-  }
-
   handleInputChange(idx, event) {
     const urls = this.props.urls;
     urls[idx][event.target.name] = event.target.value;
+    this.props.onChange(urls);
+  }
+
+  handleLinkReorder(newLinkOrder) {
+    const socialUrls = this.props.urls.filter(url => url.site);
+    const urls = newLinkOrder.concat(socialUrls);
     this.props.onChange(urls);
   }
 
@@ -40,8 +40,8 @@ export default class ExternalLinksEditor extends React.Component {
     const indexToRemove = urls.findIndex(i => (i.key === linkToRemove.key));
     if (indexToRemove > -1) {
       urls.splice(indexToRemove, 1);
+      this.props.onChange(urls);
     }
-    this.props.onChange(urls);
   }
 
   renderRow(link) {
@@ -75,7 +75,7 @@ export default class ExternalLinksEditor extends React.Component {
 
   renderTable(urls) {
     const tableUrls = urls
-      .filter(url => !url.path)
+      .filter(url => !url.site)
       .map((url) => {
         if (!url.key) {
           const newUrl = url;
@@ -110,7 +110,7 @@ export default class ExternalLinksEditor extends React.Component {
           ? this.renderTable(this.props.urls)
           : null}
 
-        <button type="button" onClick={this.handleAddLink}>Add a link</button>
+        <button type="button" onClick={this.handleAddLink}>Add external link</button>
       </div>
     );
   }

--- a/src/modules/common/components/social-links-editor.jsx
+++ b/src/modules/common/components/social-links-editor.jsx
@@ -2,15 +2,10 @@ import React from 'react';
 import DragReorderable from 'drag-reorderable';
 import SOCIAL_ICONS from '../../../lib/social-icons';
 
-export default class ExternalLinksEditor extends React.Component {
+export default class SocialLinksEditor extends React.Component {
 
   constructor(props) {
     super(props);
-
-    const socialOrder = Object.keys(SOCIAL_ICONS);
-    this.state = {
-      socialOrder
-    };
 
     this.reorderDefault = this.reorderDefault.bind(this);
     this.handleNewLink = this.handleNewLink.bind(this);
@@ -19,27 +14,11 @@ export default class ExternalLinksEditor extends React.Component {
     this.renderRow = this.renderRow.bind(this);
   }
 
-  componentDidMount() {
-    this.reorderDefault();
-  }
-
-  // not sure if we need this.
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.urls !== this.props.urls) {
-      this.reorderDefault();
-    }
-  }
-
   reorderDefault() {
-    const socialUrls = this.props.urls.filter(url => url.path);
-    const newOrder = [];
-    socialUrls.map(link => newOrder.push(link.site));
-    this.state.socialOrder.map((item) => {
-      if (newOrder.indexOf(item) < 0) {
-        newOrder.push(item);
-      }
-    });
-    this.setState({ socialOrder: newOrder });
+    const socialUrls = this.props.urls.filter(url => url.path).map(url => url.site);
+    const socialOrder = Object.keys(SOCIAL_ICONS).filter(item => socialUrls.indexOf(item) < 0);
+    const newOrder = socialUrls.concat(socialOrder);
+    return newOrder;
   }
 
   handleNewLink(site, e) {
@@ -59,7 +38,6 @@ export default class ExternalLinksEditor extends React.Component {
     } else {
       this.handleRemoveLink(site);
     }
-
   }
 
   handleLinkReorder(newLinkOrder) {
@@ -69,7 +47,6 @@ export default class ExternalLinksEditor extends React.Component {
     const changes = externalUrls.concat(newSocialUrls);
 
     this.props.onChange(changes);
-    this.setState({ socialOrder: newLinkOrder });
   }
 
   handleRemoveLink(linkToRemove) {
@@ -120,11 +97,12 @@ export default class ExternalLinksEditor extends React.Component {
   }
 
   render() {
+    const socialOrder = this.reorderDefault();
     return (
       <table className="edit-social-links">
         <DragReorderable
           tag="tbody"
-          items={this.state.socialOrder}
+          items={socialOrder}
           render={this.renderRow}
           onChange={this.handleLinkReorder}
         />
@@ -133,4 +111,14 @@ export default class ExternalLinksEditor extends React.Component {
   }
 }
 
+SocialLinksEditor.defaultProps = {
+  urls: []
+};
 
+SocialLinksEditor.propTypes = {
+  onChange: React.PropTypes.func,
+  urls: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      url: React.PropTypes.string
+    }))
+};

--- a/src/modules/common/components/social-links-editor.jsx
+++ b/src/modules/common/components/social-links-editor.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import DragReorderable from 'drag-reorderable';
+import SOCIAL_ICONS from '../../../lib/social-icons';
+
+export default class ExternalLinksEditor extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    const socialOrder = Object.keys(SOCIAL_ICONS);
+    this.state = {
+      socialOrder
+    };
+
+    this.reorderDefault = this.reorderDefault.bind(this);
+    this.handleNewLink = this.handleNewLink.bind(this);
+    this.handleLinkReorder = this.handleLinkReorder.bind(this);
+    this.handleRemoveLink = this.handleRemoveLink.bind(this);
+    this.renderRow = this.renderRow.bind(this);
+  }
+
+  componentDidMount() {
+    this.reorderDefault();
+  }
+
+  // not sure if we need this.
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.urls !== this.props.urls) {
+      this.reorderDefault();
+    }
+  }
+
+  reorderDefault() {
+    const socialUrls = this.props.urls.filter(url => url.path);
+    const newOrder = [];
+    socialUrls.map(link => newOrder.push(link.site));
+    this.state.socialOrder.map((item) => {
+      if (newOrder.indexOf(item) < 0) {
+        newOrder.push(item);
+      }
+    });
+    this.setState({ socialOrder: newOrder });
+  }
+
+  handleNewLink(site, e) {
+    let index = this.indexFinder(this.props.urls, site);
+    if (index < 0) { index = this.props.urls.length; }
+
+    if (e.target.value) {
+      const changes = {
+        label: '',
+        path: e.target.value,
+        site,
+        url: `https://${site}${e.target.value}`
+      };
+      const urls = this.props.urls;
+      urls[index] = changes;
+      this.props.onChange(urls);
+    } else {
+      this.handleRemoveLink(site);
+    }
+
+  }
+
+  handleLinkReorder(newLinkOrder) {
+    const externalUrls = this.props.urls.filter(url => !url.path);
+    const socialUrls = this.props.urls.filter(url => url.path);
+    const newSocialUrls = socialUrls.sort((a, b) => newLinkOrder.indexOf(a.site) - newLinkOrder.indexOf(b.site));
+    const changes = externalUrls.concat(newSocialUrls);
+
+    this.props.onChange(changes);
+    this.setState({ socialOrder: newLinkOrder });
+  }
+
+  handleRemoveLink(linkToRemove) {
+    const urls = this.props.urls.slice();
+    const indexToRemove = this.indexFinder(urls, linkToRemove);
+    if (indexToRemove > -1) {
+      urls.splice(indexToRemove, 1);
+      this.props.onChange(urls);
+    }
+  }
+
+  handleDisableDrag(event) {
+    event.target.parentElement.parentElement.parentElement.setAttribute('draggable', false);
+  }
+
+  handleEnableDrag(event) {
+    event.target.parentElement.parentElement.parentElement.setAttribute('draggable', true);
+  }
+
+  indexFinder(toSearch, toFind) {
+    return toSearch.findIndex(i => (i.site === toFind));
+  }
+
+  renderRow(site, i) {
+    const index = this.indexFinder(this.props.urls, site);
+    const value = index >= 0 ? this.props.urls[index].path : '';
+
+    return (
+      <tr key={i}>
+        <td>{site}</td>
+        <td>
+          <input
+            type="text"
+            name={`urls.${site}.url`}
+            value={value}
+            onChange={this.handleNewLink.bind(this, site)}
+            onMouseDown={this.handleDisableDrag}
+            onMouseUp={this.handleEnableDrag}
+          />
+        </td>
+        <td>
+          <button type="button" onClick={this.handleRemoveLink.bind(this, site)}>
+            <i className="fa fa-remove" />
+          </button>
+        </td>
+      </tr>
+    );
+  }
+
+  render() {
+    return (
+      <table className="edit-social-links">
+        <DragReorderable
+          tag="tbody"
+          items={this.state.socialOrder}
+          render={this.renderRow}
+          onChange={this.handleLinkReorder}
+        />
+      </table>
+    );
+  }
+}
+
+

--- a/src/modules/common/components/social-links-editor.jsx
+++ b/src/modules/common/components/social-links-editor.jsx
@@ -7,88 +7,62 @@ export default class SocialLinksEditor extends React.Component {
   constructor(props) {
     super(props);
 
-    this.reorderDefault = this.reorderDefault.bind(this);
-    this.handleNewLink = this.handleNewLink.bind(this);
+    this.handleAddLink = this.handleAddLink.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
     this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleRemoveLink = this.handleRemoveLink.bind(this);
     this.renderRow = this.renderRow.bind(this);
   }
 
-  reorderDefault() {
-    const socialUrls = this.props.urls.filter(url => url.path).map(url => url.site);
-    const socialOrder = Object.keys(SOCIAL_ICONS).filter(item => socialUrls.indexOf(item) < 0);
-    const newOrder = socialUrls.concat(socialOrder);
-    return newOrder;
+  handleAddLink(e) {
+    const newUrl = {
+      label: '',
+      path: '',
+      site: e.target.value,
+      url: `https://${e.target.value}`
+    };
+    const urls = this.props.urls;
+    urls.push(newUrl);
+    this.props.onChange(urls);
   }
 
-  handleNewLink(site, e) {
-    let index = this.indexFinder(this.props.urls, site);
-    if (index < 0) { index = this.props.urls.length; }
-
-    if (e.target.value) {
-      const changes = {
-        label: '',
-        path: e.target.value,
-        site,
-        url: `https://${site}${e.target.value}`
-      };
-      const urls = this.props.urls;
-      urls[index] = changes;
-      this.props.onChange(urls);
-    } else {
-      this.handleRemoveLink(site);
-    }
+  handleInputChange(idx, event) {
+    const urls = this.props.urls;
+    urls[idx].path = event.target.value;
+    this.props.onChange(urls);
   }
 
   handleLinkReorder(newLinkOrder) {
-    const externalUrls = this.props.urls.filter(url => !url.path);
-    const socialUrls = this.props.urls.filter(url => url.path);
-    const newSocialUrls = socialUrls.sort((a, b) => newLinkOrder.indexOf(a.site) - newLinkOrder.indexOf(b.site));
-    const changes = externalUrls.concat(newSocialUrls);
-
-    this.props.onChange(changes);
+    const externalUrls = this.props.urls.filter(url => !url.site);
+    const urls = externalUrls.concat(newLinkOrder);
+    this.props.onChange(urls);
   }
 
   handleRemoveLink(linkToRemove) {
-    const urls = this.props.urls.slice();
-    const indexToRemove = this.indexFinder(urls, linkToRemove);
+    const urls = this.props.urls;
+    const indexToRemove = urls.indexOf(linkToRemove);
     if (indexToRemove > -1) {
       urls.splice(indexToRemove, 1);
       this.props.onChange(urls);
     }
   }
 
-  handleDisableDrag(event) {
-    event.target.parentElement.parentElement.parentElement.setAttribute('draggable', false);
-  }
-
-  handleEnableDrag(event) {
-    event.target.parentElement.parentElement.parentElement.setAttribute('draggable', true);
-  }
-
-  indexFinder(toSearch, toFind) {
-    return toSearch.findIndex(i => (i.site === toFind));
-  }
-
-  renderRow(site, i) {
-    const index = this.indexFinder(this.props.urls, site);
-    const value = index >= 0 ? this.props.urls[index].path : '';
-
+  renderRow(link) {
+    const idx = this.props.urls.findIndex(i => (i.site === link.site));
     return (
-      <tr key={i}>
-        <td>{site}</td>
+      <tr key={idx}>
+        <td>{link.site}</td>
         <td>
           <input
             type="text"
-            name={`urls.${site}.url`}
-            value={value}
-            onChange={this.handleNewLink.bind(this, site)}
+            value={link.path || ''}
+            onChange={this.handleInputChange.bind(this, idx)}
             onMouseDown={this.handleDisableDrag}
             onMouseUp={this.handleEnableDrag}
           />
         </td>
         <td>
-          <button type="button" onClick={this.handleRemoveLink.bind(this, site)}>
+          <button type="button" onClick={this.handleRemoveLink.bind(this, link)}>
             <i className="fa fa-remove" />
           </button>
         </td>
@@ -97,17 +71,27 @@ export default class SocialLinksEditor extends React.Component {
   }
 
   render() {
-    const socialOrder = this.reorderDefault();
+    const socialUrls = this.props.urls.filter(url => url.site);
+    const socialOptions = Object.keys(SOCIAL_ICONS)
+      .filter(item => socialUrls.map(url => url.site).indexOf(item) < 0);
     return (
-      <table className="edit-social-links">
-        <DragReorderable
-          tag="tbody"
-          items={socialOrder}
-          render={this.renderRow}
-          onChange={this.handleLinkReorder}
-        />
-      </table>
-    );
+      <div>
+        <table className="edit-social-links">
+          <DragReorderable
+            tag="tbody"
+            items={socialUrls}
+            render={this.renderRow}
+            onChange={this.handleLinkReorder}
+          />
+        </table>
+        <label htmlFor="social link">
+          Add social link:{' '}
+          <select value="stuck" onChange={this.handleAddLink}>
+            <option value="stuck" disabled>Social links...</option>
+            {socialOptions.map(item => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
+      </div>);
   }
 }
 

--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { organizationShape, organizationAvatarShape, organizationBackgroundShape } from '../model';
 import DetailsFormContainer from '../containers/details-form-container';
+import LinksContainer from '../containers/links-container';
 import ImageSelector from '../../common/containers/image-selector';
 
 const EditDetails = (props) => {
@@ -43,6 +44,9 @@ const EditDetails = (props) => {
         </aside>
         <section className="forms__section">
           <DetailsFormContainer updateOrganization={props.updateOrganization} />
+          <hr />
+          <LinksContainer updateOrganization={props.updateOrganization} />
+          <hr />
           <span className="form__label">Status</span>
           <div>
             <span>

--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -47,24 +47,26 @@ const EditDetails = (props) => {
           <hr />
           <LinksContainer updateOrganization={props.updateOrganization} />
           <hr />
-          <span className="form__label">Status</span>
           <div>
-            <span>
-              Listed:{' '}
-              <span className={props.organization.listed ? 'color-label green' : 'color-label red'}>
-                {props.organization.listed.toString()}
+            <h5>Status</h5>
+            <div>
+              <span>
+                Listed:{' '}
+                <span className={props.organization.listed ? 'color-label green' : 'color-label red'}>
+                  {props.organization.listed.toString()}
+                </span>
               </span>
-            </span>
-            <br />
-            <span>
-              Listed At:{' '}
-              {props.organization.listed ? Date(props.organization.listed_at) : 'N/A'}
-            </span>
+              <br />
+              <span>
+                Listed At:{' '}
+                {props.organization.listed ? Date(props.organization.listed_at) : 'N/A'}
+              </span>
+            </div>
+            <small>
+              Status indicates whether an organization is publicly visible (TRUE) or not publicly visible (FALSE).
+              Please contact the Zooniverse team via Talk (use @team or @admin) to change the status of an organization.
+            </small>
           </div>
-          <small>
-            Status indicates whether an organization is publicly visible (TRUE) or not publicly visible (FALSE).
-            Please contact the Zooniverse team via Talk (use @team or @admin) to change the status of an organization.
-          </small>
           <hr />
           <button
             type="button"

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -10,6 +10,8 @@ import bindInput from '../../common/containers/bind-input';
 import FormContainer from '../../common/containers/form-container';
 import CharLimit from '../../common/components/char-limit';
 
+import ExternalLinksEditor from '../../common/components/external-links-editor';
+
 class DetailsFormContainer extends React.Component {
   constructor(props) {
     super(props);
@@ -17,21 +19,30 @@ class DetailsFormContainer extends React.Component {
     this.collectValues = this.collectValues.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleTextAreaChange = this.handleTextAreaChange.bind(this);
+    this.handleUrlsChange = this.handleUrlsChange.bind(this);
     this.resetOrganization = this.resetOrganization.bind(this);
 
     this.state = {
-      textarea: ''
+      textarea: '',
+      urls: []
     };
   }
 
   componentDidMount() {
-    this.setState({ textarea: this.props.organization.introduction });
+    this.setState({
+      textarea: this.props.organization.introduction,
+      urls: this.props.organization.urls
+    });
   }
 
   handleTextAreaChange(event) {
     const textarea = event.target.value;
 
     this.setState({ textarea });
+  }
+
+  handleUrlsChange(urls) {
+    this.setState({ urls });
   }
 
   collectValues() {
@@ -42,6 +53,7 @@ class DetailsFormContainer extends React.Component {
       result[fieldName] = this.fields[fieldName].value();
     });
     result.introduction = this.state.textarea;
+    result.urls = this.state.urls;
     return result;
   }
 
@@ -105,6 +117,20 @@ class DetailsFormContainer extends React.Component {
               Add a brief introduction to get people interested in your organization.
               This will display on your landing page.{' '}
               <CharLimit limit={1500} string={this.state.textarea || ''} />
+            </small>
+          </fieldset>
+          <fieldset>
+            <label className="form__label" htmlFor="external urls">
+              External Links
+              <ExternalLinksEditor
+                id="external"
+                name="external"
+                onChange={this.handleUrlsChange}
+                urls={this.state.urls}
+              />
+            </label>
+            <small className="form__help">
+              External URLs blah blah blah.
             </small>
           </fieldset>
         </FormContainer>

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -65,6 +65,7 @@ class DetailsFormContainer extends React.Component {
 
     return (
       <div>
+        <h5>Details</h5>
         <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
           <fieldset className="form__fieldset">
             <DisplayNameSlugEditor

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -11,6 +11,7 @@ import FormContainer from '../../common/containers/form-container';
 import CharLimit from '../../common/components/char-limit';
 
 import ExternalLinksEditor from '../../common/components/external-links-editor';
+import SocialLinksEditor from '../../common/components/social-links-editor';
 
 class DetailsFormContainer extends React.Component {
   constructor(props) {
@@ -119,7 +120,7 @@ class DetailsFormContainer extends React.Component {
               <CharLimit limit={1500} string={this.state.textarea || ''} />
             </small>
           </fieldset>
-          <fieldset>
+          <fieldset className="form__fieldset">
             <label className="form__label" htmlFor="external urls">
               External Links
               <ExternalLinksEditor
@@ -130,7 +131,22 @@ class DetailsFormContainer extends React.Component {
               />
             </label>
             <small className="form__help">
-              External URLs blah blah blah.
+              Adding an external link will make it appear as a new tab alongside
+              the about, classify, talk, and collect tabs.
+            </small>
+          </fieldset>
+          <fieldset className="form__fieldset">
+            <label className="form__label" htmlFor="social urls">
+              Social Links
+              <SocialLinksEditor
+                id="social"
+                name="social"
+                onChange={this.handleUrlsChange}
+                urls={this.state.urls}
+              />
+            </label>
+            <small className="form__help">
+              Adding a social link will append a media icon at the end of your project menu bar.
             </small>
           </fieldset>
         </FormContainer>

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -10,9 +10,6 @@ import bindInput from '../../common/containers/bind-input';
 import FormContainer from '../../common/containers/form-container';
 import CharLimit from '../../common/components/char-limit';
 
-import ExternalLinksEditor from '../../common/components/external-links-editor';
-import SocialLinksEditor from '../../common/components/social-links-editor';
-
 class DetailsFormContainer extends React.Component {
   constructor(props) {
     super(props);
@@ -20,30 +17,21 @@ class DetailsFormContainer extends React.Component {
     this.collectValues = this.collectValues.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleTextAreaChange = this.handleTextAreaChange.bind(this);
-    this.handleUrlsChange = this.handleUrlsChange.bind(this);
     this.resetOrganization = this.resetOrganization.bind(this);
 
     this.state = {
-      textarea: '',
-      urls: []
+      textarea: ''
     };
   }
 
   componentDidMount() {
-    this.setState({
-      textarea: this.props.organization.introduction,
-      urls: this.props.organization.urls
-    });
+    this.setState({ textarea: this.props.organization.introduction });
   }
 
   handleTextAreaChange(event) {
     const textarea = event.target.value;
 
     this.setState({ textarea });
-  }
-
-  handleUrlsChange(urls) {
-    this.setState({ urls });
   }
 
   collectValues() {
@@ -54,7 +42,6 @@ class DetailsFormContainer extends React.Component {
       result[fieldName] = this.fields[fieldName].value();
     });
     result.introduction = this.state.textarea;
-    result.urls = this.state.urls;
     return result;
   }
 
@@ -118,35 +105,6 @@ class DetailsFormContainer extends React.Component {
               Add a brief introduction to get people interested in your organization.
               This will display on your landing page.{' '}
               <CharLimit limit={1500} string={this.state.textarea || ''} />
-            </small>
-          </fieldset>
-          <fieldset className="form__fieldset">
-            <label className="form__label" htmlFor="external urls">
-              External Links
-              <ExternalLinksEditor
-                id="external"
-                name="external"
-                onChange={this.handleUrlsChange}
-                urls={this.state.urls}
-              />
-            </label>
-            <small className="form__help">
-              Adding an external link will make it appear as a new tab alongside
-              the about, classify, talk, and collect tabs.
-            </small>
-          </fieldset>
-          <fieldset className="form__fieldset">
-            <label className="form__label" htmlFor="social urls">
-              Social Links
-              <SocialLinksEditor
-                id="social"
-                name="social"
-                onChange={this.handleUrlsChange}
-                urls={this.state.urls}
-              />
-            </label>
-            <small className="form__help">
-              Adding a social link will append a media icon at the end of your project menu bar.
             </small>
           </fieldset>
         </FormContainer>

--- a/src/modules/organizations/containers/links-container.jsx
+++ b/src/modules/organizations/containers/links-container.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { setCurrentOrganization } from '../action-creators';
+import { organizationShape } from '../model';
+import ExternalLinksEditor from '../../common/components/external-links-editor';
+import SocialLinksEditor from '../../common/components/social-links-editor';
+
+class LinksContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleUrlsChange = this.handleUrlsChange.bind(this);
+    this.resetOrganization = this.resetOrganization.bind(this);
+
+    this.state = {
+      urls: []
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      urls: this.props.organization.urls
+    });
+  }
+
+  handleSubmit() {
+    this.setState({ show: false });
+    this.props.updateOrganization({ urls: this.state.urls });
+  }
+
+  handleUrlsChange(urls) {
+    this.setState({ show: true, urls });
+  }
+
+  resetOrganization() {
+    this.setState({ show: false });
+    this.props.dispatch(setCurrentOrganization(this.props.organization));
+  }
+
+  render() {
+    return (
+      <div>
+        <div>
+          <span className="form__label" htmlFor="external urls">
+            External Links
+            <ExternalLinksEditor
+              id="external"
+              name="external"
+              onChange={this.handleUrlsChange}
+              urls={this.state.urls}
+            />
+          </span>
+          <small className="form__help">
+            Adding an external link will make it appear as a new tab alongside
+            the about, classify, talk, and collect tabs.
+          </small>
+        </div>
+        <br />
+        <div className="form__fieldset">
+          <span className="form__label">
+            Social Links
+            <SocialLinksEditor
+              id="social"
+              name="social"
+              onChange={this.handleUrlsChange}
+              urls={this.state.urls}
+            />
+          </span>
+          <small className="form__help">
+            Adding a social link will append a media icon at the end of your project menu bar.
+          </small>
+        </div>
+        {this.state.show &&
+        <div>
+          <button onClick={this.handleSubmit}>Save</button>
+          <button onClick={this.resetOrganization}>Cancel</button>
+        </div>}
+      </div>);
+  }
+}
+
+LinksContainer.defaultProps = {
+  organization: {},
+};
+
+LinksContainer.propTypes = {
+  dispatch: PropTypes.func,
+  organization: organizationShape,
+  updateOrganization: PropTypes.func
+};
+
+function mapStateToProps(state) {
+  return {
+    organization: state.organization,
+  };
+}
+
+export default connect(mapStateToProps)(LinksContainer);

--- a/src/modules/organizations/containers/links-container.jsx
+++ b/src/modules/organizations/containers/links-container.jsx
@@ -27,7 +27,8 @@ class LinksContainer extends React.Component {
 
   handleSubmit() {
     this.setState({ show: false });
-    this.props.updateOrganization({ urls: this.state.urls });
+    const filteredUrls = this.state.urls.filter(url => url.label || url.path);
+    this.props.updateOrganization({ urls: filteredUrls });
   }
 
   handleUrlsChange(urls) {
@@ -42,6 +43,7 @@ class LinksContainer extends React.Component {
   render() {
     return (
       <div>
+        <h5>Links</h5>
         <div>
           <span className="form__label" htmlFor="external urls">
             External Links


### PR DESCRIPTION
Closes #108.

Based on PFE [external links editor](https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/lab/external-links-editor.jsx) and [social links editor](https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/lab/social-links-editor.jsx).

Staged - https://urls-editors.lab-preview.zooniverse.org/

Replaces #125 - due to issues with new social links as detailed in PR noted, this PR reflects a select for new social links; I think preferable.

Will improve styling with #122, address Cancel button issue in separate PR.