### PR TITLE
Add existential check for org projects

### DIFF
--- a/src/modules/organizations/containers/projects-container.jsx
+++ b/src/modules/organizations/containers/projects-container.jsx
@@ -44,7 +44,7 @@ class ProjectsContainer extends React.Component {
   }
 
   getLinkedProjects(organization = this.props.organization, page = 1) {
-    if (!organization) {
+    if (!organization || !organization.links.projects) {
       return;
     }
 


### PR DESCRIPTION
## Describe Changes
- Adds a conditional check for projects affiliated with an organization. If no projects, return nothing and do not run `getLinkedProjects`.
- Fixes #131. 
- [Staged here](https://no-projects-error.lab-preview.zooniverse.org/).
- No spec file currently made for `ProjectsContainer`, so didn't create one just for this simple check - happy to undertake testing projects container if desired :) 