### PR TITLE
Format org listed_at date

### DIFF
--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -14,7 +14,7 @@ const EditDetails = (props) => {
     );
   }
 
-  if (props.organization.listed) {
+  if (props.organization.listed_at) {
     listedAtDate = new Date(props.organization.listed_at).toDateString();
   }
 

--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -6,10 +6,16 @@ import LinksContainer from '../containers/links-container';
 import ImageSelector from '../../common/containers/image-selector';
 
 const EditDetails = (props) => {
+  let listedAtDate;
+
   if (!props.organization) {
     return (
       <div>Loading...</div>
     );
+  }
+
+  if (props.organization.listed) {
+    listedAtDate = new Date(props.organization.listed_at).toDateString();
   }
 
   return (
@@ -59,7 +65,7 @@ const EditDetails = (props) => {
               <br />
               <span>
                 Listed At:{' '}
-                {props.organization.listed ? Date(props.organization.listed_at) : 'N/A'}
+                {props.organization.listed ? listedAtDate : 'N/A'}
               </span>
             </div>
             <small>

--- a/test/modules/organizations/components/edit-details-test.js
+++ b/test/modules/organizations/components/edit-details-test.js
@@ -3,11 +3,14 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { organization, organizationAvatar, organizationBackground } from '../test-data';
+import { organizations, organizationAvatar, organizationBackground } from '../test-data';
 
 import EditDetails from '../../../../src/modules/organizations/components/edit-details';
 import DetailsFormContainer from '../../../../src/modules/organizations/containers/details-form-container';
 import ImageSelector from '../../../../src/modules/common/containers/image-selector';
+
+const listedOrganization = organizations[0];
+const unlistedOrganization = organizations[1];
 
 describe('<EditDetails />', function() {
   let wrapper;
@@ -17,7 +20,7 @@ describe('<EditDetails />', function() {
     wrapper = shallow(
       <EditDetails
         deleteOrganization={deleteOrganizationSpy}
-        organization={organization}
+        organization={listedOrganization}
         organizationAvatar={organizationAvatar}
         organizationBackground={organizationBackground}
       />
@@ -41,5 +44,15 @@ describe('<EditDetails />', function() {
     const deleteButton = wrapper.find('button.button--full-alert');
     deleteButton.simulate('click');
     expect(deleteOrganizationSpy.calledOnce).to.be.true;
+  });
+
+  it('should render a listed_at date when passed a listed organization', function() {
+    const formattedDate = new Date(listedOrganization.listed_at).toDateString();
+    expect(wrapper.find('span').last().text()).to.equal(`Listed At: ${formattedDate}`);
+  });
+
+  it('should render "N/A" when passed an unlisted organization', function() {
+    wrapper.setProps({ organization: unlistedOrganization });
+    expect(wrapper.find('span').last().text()).to.equal('Listed At: N/A');
   });
 });

--- a/test/modules/organizations/test-data.js
+++ b/test/modules/organizations/test-data.js
@@ -10,7 +10,8 @@ export const organizations = [
     links: {
       owner: { display_name: 'Bob' }
     },
-    listed: true
+    listed: true,
+    listed_at: "2017-10-25T18:54:02.604Z"
   },
   {
     id: '42',


### PR DESCRIPTION
## Describe Changes
- Formats the display of an organization's `listed_at` date for better readability.
- Includes check on boolean property `props.organization.listed` before formatting the `listed_at` date
  - `props.organization.listed` is also used in the ternary for conditionally rendering either the new listedAtDate or "N/A" according to an organization's `listed` status.
- Adds unit tests for presence of a formatted date when `props.organization.listed` is true, and renders "N/A" when false.
- [Staged here](https://listed-at-date-format.lab-preview.zooniverse.org/organizations/2).