### PR TITLE
Initial design changes

### DIFF
--- a/src/modules/common/components/external-links-editor.jsx
+++ b/src/modules/common/components/external-links-editor.jsx
@@ -86,7 +86,7 @@ export default class ExternalLinksEditor extends React.Component {
       });
 
     return (
-      <table className="external-links-table">
+      <table className="external-links-table form__input--top-margin">
         <thead>
           <tr>
             <th>Label</th>

--- a/src/modules/common/components/social-links-editor.jsx
+++ b/src/modules/common/components/social-links-editor.jsx
@@ -78,7 +78,7 @@ export default class SocialLinksEditor extends React.Component {
       .filter(item => socialUrls.map(url => url.site).indexOf(item) < 0);
     return (
       <div>
-        <table className="edit-social-links">
+        <table className="edit-social-links form__input--top-margin">
           <DragReorderable
             tag="tbody"
             items={socialUrls}

--- a/src/modules/organizations/components/about-page.jsx
+++ b/src/modules/organizations/components/about-page.jsx
@@ -36,14 +36,16 @@ const AboutPage = (props) => {
           <label className="form__label" htmlFor="content">
             About Page Content
             <br />
-            <MarkdownEditor
-              id="content"
-              name="content"
-              onChange={props.onTextAreaChange}
-              project={props.organization}
-              rows="20"
-              value={props.pageContent}
-            />
+            <div className="form__input--top-margin">
+              <MarkdownEditor
+                id="content"
+                name="content"
+                onChange={props.onTextAreaChange}
+                project={props.organization}
+                rows="20"
+                value={props.pageContent}
+              />
+            </div>
           </label>
         </fieldset>
       </FormContainer>

--- a/src/modules/organizations/components/about-page.jsx
+++ b/src/modules/organizations/components/about-page.jsx
@@ -36,16 +36,15 @@ const AboutPage = (props) => {
           <label className="form__label" htmlFor="content">
             About Page Content
             <br />
-            <div className="form__input--top-margin">
-              <MarkdownEditor
-                id="content"
-                name="content"
-                onChange={props.onTextAreaChange}
-                project={props.organization}
-                rows="20"
-                value={props.pageContent}
-              />
-            </div>
+            <MarkdownEditor
+              id="content"
+              name="content"
+              className="form__input--top-margin"
+              onChange={props.onTextAreaChange}
+              project={props.organization}
+              rows="20"
+              value={props.pageContent}
+            />
           </label>
         </fieldset>
       </FormContainer>

--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -29,6 +29,7 @@ const EditDetails = (props) => {
             />
             <small>Pick a logo to represent your organization. To add an image, either drag and drop or click to open your file viewer. For best results, use a square image of not more than 50 KB.</small>
           </div>
+          <br />
           <hr />
           <div>
             <ImageSelector

--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -44,8 +44,10 @@ const EditDetails = (props) => {
         </aside>
         <section className="forms__section">
           <DetailsFormContainer updateOrganization={props.updateOrganization} />
+          <br />
           <hr />
           <LinksContainer updateOrganization={props.updateOrganization} />
+          <br />
           <hr />
           <div>
             <h5>Status</h5>
@@ -67,6 +69,7 @@ const EditDetails = (props) => {
               Please contact the Zooniverse team via Talk (use @team or @admin) to change the status of an organization.
             </small>
           </div>
+          <br />
           <hr />
           <button
             type="button"

--- a/src/modules/organizations/components/organization-add-project.jsx
+++ b/src/modules/organizations/components/organization-add-project.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ProjectSearch from '../../common/components/project-search';
 import FormContainer from '../../common/containers/form-container';
+import { config } from '../../../constants/config';
 
 const OrganizationAddProject = ({ value, onAdd, onChange, onReset }) =>
   (<div>
@@ -36,6 +37,9 @@ const OrganizationAddProject = ({ value, onAdd, onChange, onReset }) =>
         Contact the other organization collaborators to get access to this project.
       </li>
     </ul>
+    <div>
+      <a href={`${config.zooniverseURL}/lab`} className="button button--full-major">Build a Project</a>
+    </div>
   </div>);
 
 OrganizationAddProject.propTypes = {

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -68,7 +68,7 @@ class DetailsFormContainer extends React.Component {
         <h5>Details</h5>
         <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
           <fieldset className="form__fieldset">
-            <label className="form__label" htmlFor="display_name">
+            <label className="form__label">
               <DisplayNameSlugEditor
                 origin={config.zooniverseURL}
                 resource={organization}
@@ -78,7 +78,7 @@ class DetailsFormContainer extends React.Component {
             </label>
           </fieldset>
           <fieldset className="form__fieldset">
-            <label className="form__label" htmlFor="description">
+            <label className="form__label">
               Description
               <DescriptionInput
                 className="form__input form__input--full-width"
@@ -93,18 +93,17 @@ class DetailsFormContainer extends React.Component {
             </small>
           </fieldset>
           <fieldset className="form__fieldset">
-            <label className="form__label" htmlFor="introduction">
+            <label className="form__label">
               Introduction
-              <div className="form__input--top-margin">
-                <MarkdownEditor
-                  id="introduction"
-                  name="introduction"
-                  onChange={this.handleTextAreaChange}
-                  project={this.props.organization}
-                  rows="10"
-                  value={this.state.textarea}
-                />
-              </div>
+              <MarkdownEditor
+                id="introduction"
+                name="introduction"
+                className="form__input--top-margin"
+                onChange={this.handleTextAreaChange}
+                project={this.props.organization}
+                rows="10"
+                value={this.state.textarea}
+              />
             </label>
             <small className="form__help">
               Add a brief introduction to get people interested in your organization.

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -86,29 +86,31 @@ class DetailsFormContainer extends React.Component {
                 ref={(node) => { this.fields.description = node; }}
               />
             </label>
-            <p className="form__help">
+            <small className="form__help">
               This should be a one-line call to action for your organization that displays on your landing page.
               It will be displayed below the organization&apos;s name.{' '}
               <CharLimit limit={300} string={this.props.organization.description || ''} />
-            </p>
+            </small>
           </fieldset>
           <fieldset className="form__fieldset">
-            <label htmlFor="introduction">
+            <label className="form__label" htmlFor="introduction">
               Introduction
-              <MarkdownEditor
-                id="introduction"
-                name="introduction"
-                onChange={this.handleTextAreaChange}
-                project={this.props.organization}
-                rows="10"
-                value={this.state.textarea}
-              />
+              <div className="form__input--top-margin">
+                <MarkdownEditor
+                  id="introduction"
+                  name="introduction"
+                  onChange={this.handleTextAreaChange}
+                  project={this.props.organization}
+                  rows="10"
+                  value={this.state.textarea}
+                />
+              </div>
             </label>
-            <p className="form__help">
+            <small className="form__help">
               Add a brief introduction to get people interested in your organization.
               This will display on your landing page.{' '}
               <CharLimit limit={1500} string={this.state.textarea || ''} />
-            </p>
+            </small>
           </fieldset>
         </FormContainer>
       </div>

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -68,12 +68,14 @@ class DetailsFormContainer extends React.Component {
         <h5>Details</h5>
         <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
           <fieldset className="form__fieldset">
-            <DisplayNameSlugEditor
-              origin={config.zooniverseURL}
-              resource={organization}
-              resourceType="organization"
-              ref={(node) => { this.fields.display_name = node; }}
-            />
+            <label className="form__label" htmlFor="display_name">
+              <DisplayNameSlugEditor
+                origin={config.zooniverseURL}
+                resource={organization}
+                resourceType="organization"
+                ref={(node) => { this.fields.display_name = node; }}
+              />
+            </label>
           </fieldset>
           <fieldset className="form__fieldset">
             <label className="form__label" htmlFor="description">
@@ -84,14 +86,14 @@ class DetailsFormContainer extends React.Component {
                 ref={(node) => { this.fields.description = node; }}
               />
             </label>
-            <small className="form__help">
+            <p className="form__help">
               This should be a one-line call to action for your organization that displays on your landing page.
               It will be displayed below the organization&apos;s name.{' '}
               <CharLimit limit={300} string={this.props.organization.description || ''} />
-            </small>
+            </p>
           </fieldset>
           <fieldset className="form__fieldset">
-            <label className="form__label" htmlFor="introduction">
+            <label htmlFor="introduction">
               Introduction
               <MarkdownEditor
                 id="introduction"
@@ -102,11 +104,11 @@ class DetailsFormContainer extends React.Component {
                 value={this.state.textarea}
               />
             </label>
-            <small className="form__help">
+            <p className="form__help">
               Add a brief introduction to get people interested in your organization.
               This will display on your landing page.{' '}
               <CharLimit limit={1500} string={this.state.textarea || ''} />
-            </small>
+            </p>
           </fieldset>
         </FormContainer>
       </div>

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -71,6 +71,7 @@ class DetailsFormContainer extends React.Component {
             <label className="form__label">
               <DisplayNameSlugEditor
                 origin={config.zooniverseURL}
+                className="org-details-slug-editor"
                 resource={organization}
                 resourceType="organization"
                 ref={(node) => { this.fields.display_name = node; }}

--- a/src/modules/organizations/containers/links-container.jsx
+++ b/src/modules/organizations/containers/links-container.jsx
@@ -47,14 +47,12 @@ class LinksContainer extends React.Component {
         <div>
           <label className="form form__label" htmlFor="external urls">
             External Links
-            <div className="form__input--top-margin">
               <ExternalLinksEditor
                 id="external"
                 name="external"
                 onChange={this.handleUrlsChange}
                 urls={this.state.urls}
               />
-            </div>
           </label>
           <small className="form__help">
             Adding an external link will make it appear as a new tab alongside
@@ -65,14 +63,12 @@ class LinksContainer extends React.Component {
         <div className="form__fieldset">
           <label className="form form__label">
             Social Links
-            <div className="form__input--top-margin">
-              <SocialLinksEditor
-                id="social"
-                name="social"
-                onChange={this.handleUrlsChange}
-                urls={this.state.urls}
-              />
-            </div>
+            <SocialLinksEditor
+              id="social"
+              name="social"
+              onChange={this.handleUrlsChange}
+              urls={this.state.urls}
+            />
           </label>
           <small className="form__help">
             Adding a social link will append a media icon at the end of your project menu bar.

--- a/src/modules/organizations/containers/links-container.jsx
+++ b/src/modules/organizations/containers/links-container.jsx
@@ -45,15 +45,17 @@ class LinksContainer extends React.Component {
       <div>
         <h5>Links</h5>
         <div>
-          <span className="form__label" htmlFor="external urls">
+          <label className="form form__label" htmlFor="external urls">
             External Links
-            <ExternalLinksEditor
-              id="external"
-              name="external"
-              onChange={this.handleUrlsChange}
-              urls={this.state.urls}
-            />
-          </span>
+            <div className="form__input--top-margin">
+              <ExternalLinksEditor
+                id="external"
+                name="external"
+                onChange={this.handleUrlsChange}
+                urls={this.state.urls}
+              />
+            </div>
+          </label>
           <small className="form__help">
             Adding an external link will make it appear as a new tab alongside
             the about, classify, talk, and collect tabs.
@@ -61,15 +63,17 @@ class LinksContainer extends React.Component {
         </div>
         <br />
         <div className="form__fieldset">
-          <span className="form__label">
+          <label className="form form__label">
             Social Links
-            <SocialLinksEditor
-              id="social"
-              name="social"
-              onChange={this.handleUrlsChange}
-              urls={this.state.urls}
-            />
-          </span>
+            <div className="form__input--top-margin">
+              <SocialLinksEditor
+                id="social"
+                name="social"
+                onChange={this.handleUrlsChange}
+                urls={this.state.urls}
+              />
+            </div>
+          </label>
           <small className="form__help">
             Adding a social link will append a media icon at the end of your project menu bar.
           </small>

--- a/src/modules/organizations/containers/links-container.jsx
+++ b/src/modules/organizations/containers/links-container.jsx
@@ -45,14 +45,14 @@ class LinksContainer extends React.Component {
       <div>
         <h5>Links</h5>
         <div>
-          <label className="form form__label" htmlFor="external urls">
+          <label className="form form__label">
             External Links
-              <ExternalLinksEditor
-                id="external"
-                name="external"
-                onChange={this.handleUrlsChange}
-                urls={this.state.urls}
-              />
+            <ExternalLinksEditor
+              id="external"
+              name="external"
+              onChange={this.handleUrlsChange}
+              urls={this.state.urls}
+            />
           </label>
           <small className="form__help">
             Adding an external link will make it appear as a new tab alongside

--- a/src/styles/components/edit-details.styl
+++ b/src/styles/components/edit-details.styl
@@ -10,6 +10,7 @@
     .forms__aside
       flex: 1 1
       margin-right: 1.5vw
+      line-height: 1.25
 
     .forms__section
       flex-grow: 5

--- a/src/styles/components/edit-details.styl
+++ b/src/styles/components/edit-details.styl
@@ -14,3 +14,15 @@
 
     .forms__section
       flex-grow: 5
+
+    .org-details-slug-editor__form-input
+      margin-top: 0.5em
+      display: block
+      border: 1px solid
+      border-radius: 2px
+      box-shadow: 1px 2px 5px -1px rgba(0,0,0,0.2) inset
+      box-sizing: border-box
+      padding: 0.5em 1vw
+      width: 100%
+    .org-details-slug-editor__form-help
+      font-size: .9em

--- a/src/styles/components/image-selector.styl
+++ b/src/styles/components/image-selector.styl
@@ -7,6 +7,8 @@
     border: dashed 1px darkgray
     height: 100%
     width: 100%
+    text-align: center
+    padding: 1em 0
 
     &--without-border
       @extends .image-selector__uploader
@@ -26,7 +28,7 @@
       width: 100%
 
   &__placeholder
-    padding: 1.5em 3vw
+    padding: 1.5em 3vw 0 3vw
 
   &__loader
     display: flex

--- a/src/styles/global/buttons.styl
+++ b/src/styles/global/buttons.styl
@@ -2,7 +2,7 @@
   @extends $reset-button
   border: 2px solid
   border-radius: 7px
-  padding: 0.8em 1.4vw
+  padding: 0.6em 1.4vw
   text-align: center
   font-weight: bold
   box-shadow: 0px 2px 2px 0px rgba(0,0,0,.14)

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -16,21 +16,6 @@
     &--top-margin
       margin-top: 0.5em
 
-  &__label
-    .org-details-slug-editor__form-input
-      margin-top: 0.5em
-      display: block
-      border: 1px solid
-      border-radius: 2px
-      box-shadow: 1px 2px 5px -1px rgba(0,0,0,0.2) inset
-      box-sizing: border-box
-      padding: 0.5em 1vw
-      width: 100%
-    .org-details-slug-editor__form-help
-      font-size: .9em
-    &--top-margin
-      margin-top: 0.5em
-
   &__help
     font-size: .9em
 

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -17,19 +17,21 @@
       margin-top: 0.5em
 
   &__label
-    .slug-editor__form-input
+    .org-details-slug-editor__form-input
       margin-top: 0.5em
+      display: block
+      border: 1px solid
+      border-radius: 2px
+      box-shadow: 1px 2px 5px -1px rgba(0,0,0,0.2) inset
+      box-sizing: border-box
+      padding: 0.5em 1vw
+      width: 100%
+    .org-details-slug-editor__form-help
+      font-size: .9em
     &--top-margin
       margin-top: 0.5em
-    // font-size: .7em
-    // font-weight: bold
-    // letter-spacing: .1em
-    // opacity: .7
 
   &__help
-    font-size: .9em
-
-  small.slug-editor__form-help
     font-size: .9em
 
   &__markdown-editor

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -9,19 +9,18 @@
     box-sizing: border-box
     display: block
     padding: .5em 1vw
-    margin-top: 1em
+    margin-top: 0.5em
 
     &--full-width
       width: 100%
     &--top-margin
-      margin-top: 1em
-
+      margin-top: 0.5em
 
   &__label
-    input.slug-editor__form-input
-      margin-top: 1em
+    .slug-editor__form-input
+      margin-top: 0.5em
     &--top-margin
-      margin-top: 1em
+      margin-top: 0.5em
     // font-size: .7em
     // font-weight: bold
     // letter-spacing: .1em

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -9,15 +9,18 @@
     box-sizing: border-box
     display: block
     padding: .5em 1vw
+    margin-top: 1em
 
     &--full-width
       width: 100%
 
   &__label
-    font-size: .7em
-    font-weight: bold
-    letter-spacing: .1em
-    opacity: .7
+    input
+      margin-top: 1em
+    // font-size: .7em
+    // font-weight: bold
+    // letter-spacing: .1em
+    // opacity: .7
 
   &__markdown-editor
     textarea

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -13,14 +13,25 @@
 
     &--full-width
       width: 100%
+    &--top-margin
+      margin-top: 1em
+
 
   &__label
-    input
+    input.slug-editor__form-input
+      margin-top: 1em
+    &--top-margin
       margin-top: 1em
     // font-size: .7em
     // font-weight: bold
     // letter-spacing: .1em
     // opacity: .7
+
+  &__help
+    font-size: .9em
+
+  small.slug-editor__form-help
+    font-size: .9em
 
   &__markdown-editor
     textarea


### PR DESCRIPTION
## Describe Changes
- Towards #122.
- Makes text input labels uniform in style - uses "Name" on Edit Details page as desired style.
- Text size increased:
  - Help text size beneath text inputs increased
  - Removed `font-size` on `form_label` to increase font size
- Delete button size reduced.
- Adds more space added divider lines.
- Space under text input labels is consistent.
  - RFC: use of custom components, eg `DisplayNameSlugEditor` and `MarkdownEditor`, along with HTML inputs made it difficult for me to elegantly target the elements - current solution (below) attempts to stay within BEM conventions, but suggestions on alternative approaches are welcome.
  ```javascript
    &__label
    input.slug-editor__form-input
      margin-top: 1em
    &--top-margin
      margin-top: 1em
    ```
- About page text input label has same style as Edit Details page.
- Adds `Create project` button on org/projects page.
- [Staged here](https://edit-details-page-styling.lab-preview.zooniverse.org/).

Not labeling this as a WIP PR, but understand that this is iterative, and there may be more elegant/simple/legible solutions, or better practices, that accomplish the desired results.

## Known Issues
- The MarkdownEditor WYSIWYG buttons have lost their styling. TODO: discuss desired design.