### PR TITLE
add categories input to organization lab edit section

### DIFF
--- a/src/modules/organizations/components/categories-editor.jsx
+++ b/src/modules/organizations/components/categories-editor.jsx
@@ -14,15 +14,16 @@ export default class CategoriesEditor extends React.Component {
   }
 
   handleAddCategory() {
-    const newCategory = { key: Math.random(), category: 'Example' };
+    const newCategory = { key: this.props.categories.length, label: 'Example' };
     const categories = this.props.categories;
     categories.push(newCategory);
     this.props.onChange(categories);
   }
 
-  handleInputChange(idx, event) {
+  handleInputChange(key, event) {
     const categories = this.props.categories;
-    categories[idx].category = event.target.value;
+    const index = categories.findIndex(item => (item.key === key));
+    categories[index].label = event.target.value;
     this.props.onChange(categories);
   }
 
@@ -30,29 +31,28 @@ export default class CategoriesEditor extends React.Component {
     this.props.onChange(newCategoryOrder);
   }
 
-  handleRemoveCategory(categoryToRemove) {
+  handleRemoveCategory(key) {
     const categories = this.props.categories;
-    const indexToRemove = categories.findIndex(i => (i.key === categoryToRemove.key));
-    if (indexToRemove > -1) {
-      categories.splice(indexToRemove, 1);
+    const index = categories.findIndex(item => (item.key === key));
+    if (index > -1) {
+      categories.splice(index, 1);
       this.props.onChange(categories);
     }
   }
 
   renderRow(categoryObject) {
-    const idx = this.props.categories.findIndex(i => (i.key === categoryObject.key));
     return (
       <tr key={categoryObject.key}>
         <td>
           <input
             type="text"
             name="category"
-            value={categoryObject.category}
-            onChange={this.handleInputChange.bind(this, idx)}
+            value={categoryObject.label}
+            onChange={this.handleInputChange.bind(this, categoryObject.key)}
           />
         </td>
         <td>
-          <button onClick={this.handleRemoveCategory.bind(this, categoryObject)} type="button">
+          <button onClick={this.handleRemoveCategory.bind(this, categoryObject.key)} type="button">
             <i className="fa fa-remove" />
           </button>
         </td>
@@ -100,7 +100,7 @@ CategoriesEditor.propTypes = {
   categories: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       key: React.PropTypes.num,
-      category: React.PropTypes.string
+      label: React.PropTypes.string
     })
   )
 };

--- a/src/modules/organizations/components/categories-editor.jsx
+++ b/src/modules/organizations/components/categories-editor.jsx
@@ -14,17 +14,15 @@ export default class CategoriesEditor extends React.Component {
   }
 
   handleAddCategory() {
-    const newCategory = 'Example';
+    const newCategory = { key: Math.random(), category: 'Example' };
     const categories = this.props.categories;
-    if (categories.indexOf(newCategory) === -1) {
-      categories.push(newCategory);
-      this.props.onChange(categories);
-    }
+    categories.push(newCategory);
+    this.props.onChange(categories);
   }
 
   handleInputChange(idx, event) {
     const categories = this.props.categories;
-    categories[idx] = event.target.value;
+    categories[idx].category = event.target.value;
     this.props.onChange(categories);
   }
 
@@ -34,27 +32,27 @@ export default class CategoriesEditor extends React.Component {
 
   handleRemoveCategory(categoryToRemove) {
     const categories = this.props.categories;
-    const indexToRemove = categories.indexOf(categoryToRemove);
+    const indexToRemove = categories.findIndex(i => (i.key === categoryToRemove.key));
     if (indexToRemove > -1) {
       categories.splice(indexToRemove, 1);
       this.props.onChange(categories);
     }
   }
 
-  renderRow(category) {
-    const idx = this.props.categories.indexOf(category);
+  renderRow(categoryObject) {
+    const idx = this.props.categories.findIndex(i => (i.key === categoryObject.key));
     return (
-      <tr key={idx}>
+      <tr key={categoryObject.key}>
         <td>
           <input
             type="text"
             name="category"
-            value={category}
+            value={categoryObject.category}
             onChange={this.handleInputChange.bind(this, idx)}
           />
         </td>
         <td>
-          <button onClick={this.handleRemoveCategory.bind(this, category)} type="button">
+          <button onClick={this.handleRemoveCategory.bind(this, categoryObject)} type="button">
             <i className="fa fa-remove" />
           </button>
         </td>
@@ -100,6 +98,9 @@ CategoriesEditor.defaultProps = {
 CategoriesEditor.propTypes = {
   onChange: React.PropTypes.func,
   categories: React.PropTypes.arrayOf(
-    React.PropTypes.string
+    React.PropTypes.shape({
+      key: React.PropTypes.num,
+      category: React.PropTypes.string
+    })
   )
 };

--- a/src/modules/organizations/components/categories-editor.jsx
+++ b/src/modules/organizations/components/categories-editor.jsx
@@ -16,8 +16,10 @@ export default class CategoriesEditor extends React.Component {
   handleAddCategory() {
     const newCategory = 'Example';
     const categories = this.props.categories;
-    categories.push(newCategory);
-    this.props.onChange(categories);
+    if (categories.indexOf(newCategory) === -1) {
+      categories.push(newCategory);
+      this.props.onChange(categories);
+    }
   }
 
   handleInputChange(idx, event) {

--- a/src/modules/organizations/components/categories-editor.jsx
+++ b/src/modules/organizations/components/categories-editor.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import DragReorderable from 'drag-reorderable';
+
+export default class CategoriesEditor extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleAddCategory = this.handleAddCategory.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleCategoryReorder = this.handleCategoryReorder.bind(this);
+    this.handleRemoveCategory = this.handleRemoveCategory.bind(this);
+    this.renderRow = this.renderRow.bind(this);
+    this.renderTable = this.renderTable.bind(this);
+  }
+
+  handleAddCategory() {
+    const newCategory = 'Example';
+    const categories = this.props.categories;
+    categories.push(newCategory);
+    this.props.onChange(categories);
+  }
+
+  handleInputChange(idx, event) {
+    const categories = this.props.categories;
+    categories[idx] = event.target.value;
+    this.props.onChange(categories);
+  }
+
+  handleCategoryReorder(newCategoryOrder) {
+    this.props.onChange(newCategoryOrder);
+  }
+
+  handleRemoveCategory(categoryToRemove) {
+    const categories = this.props.categories;
+    const indexToRemove = categories.indexOf(categoryToRemove);
+    if (indexToRemove > -1) {
+      categories.splice(indexToRemove, 1);
+      this.props.onChange(categories);
+    }
+  }
+
+  renderRow(category) {
+    const idx = this.props.categories.indexOf(category);
+    return (
+      <tr key={idx}>
+        <td>
+          <input
+            type="text"
+            name="category"
+            value={category}
+            onChange={this.handleInputChange.bind(this, idx)}
+          />
+        </td>
+        <td>
+          <button onClick={this.handleRemoveCategory.bind(this, category)} type="button">
+            <i className="fa fa-remove" />
+          </button>
+        </td>
+      </tr>
+    );
+  }
+
+  renderTable(categories) {
+    return (
+      <table className="external-links-table">
+        <thead>
+          <tr>
+            <th>Category</th>
+          </tr>
+        </thead>
+        <DragReorderable
+          tag="tbody"
+          items={categories}
+          render={this.renderRow}
+          onChange={this.handleCategoryReorder}
+        />
+      </table>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {(this.props.categories.length > 0)
+          ? this.renderTable(this.props.categories)
+          : null}
+
+        <button type="button" onClick={this.handleAddCategory}>Add category</button>
+      </div>
+    );
+  }
+}
+
+CategoriesEditor.defaultProps = {
+  categories: []
+};
+
+CategoriesEditor.propTypes = {
+  onChange: React.PropTypes.func,
+  categories: React.PropTypes.arrayOf(
+    React.PropTypes.string
+  )
+};

--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { organizationShape, organizationAvatarShape, organizationBackgroundShape } from '../model';
 import DetailsFormContainer from '../containers/details-form-container';
 import LinksContainer from '../containers/links-container';
+import CategoriesContainer from '../containers/categories-container';
 import ImageSelector from '../../common/containers/image-selector';
 
 const EditDetails = (props) => {
@@ -52,6 +53,8 @@ const EditDetails = (props) => {
           <DetailsFormContainer updateOrganization={props.updateOrganization} />
           <hr />
           <LinksContainer updateOrganization={props.updateOrganization} />
+          <hr />
+          <CategoriesContainer updateOrganization={props.updateOrganization} />
           <hr />
           <div>
             <h5>Status</h5>

--- a/src/modules/organizations/containers/categories-container.jsx
+++ b/src/modules/organizations/containers/categories-container.jsx
@@ -19,14 +19,19 @@ class CategoriesContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      categories: this.props.organization.categories
-    });
+    this.setCategories();
+  }
+
+  setCategories() {
+    const categoriesWithKeys = this.props.organization.categories
+      .map(category => Object.assign({}, { key: Math.random(), category }));
+    this.setState({ categories: categoriesWithKeys });
   }
 
   handleSubmit() {
+    const categories = this.state.categories.map(categoryObject => categoryObject.category);
     this.setState({ show: false });
-    this.props.updateOrganization({ categories: this.state.categories });
+    this.props.updateOrganization({ categories });
   }
 
   handleChange(categories) {
@@ -53,7 +58,8 @@ class CategoriesContainer extends React.Component {
             />
           </span>
           <small className="form__help">
-            Categories blah blah blah.
+            Add categories for volunteers to filter your projects by.
+            A project must have a tag that matches a category to be filtered.
           </small>
         </div>
         {this.state.show &&

--- a/src/modules/organizations/containers/categories-container.jsx
+++ b/src/modules/organizations/containers/categories-container.jsx
@@ -14,7 +14,8 @@ class CategoriesContainer extends React.Component {
     this.resetOrganization = this.resetOrganization.bind(this);
 
     this.state = {
-      categories: []
+      categories: [],
+      show: false
     };
   }
 
@@ -24,12 +25,12 @@ class CategoriesContainer extends React.Component {
 
   setCategories() {
     const categoriesWithKeys = this.props.organization.categories
-      .map(category => Object.assign({}, { key: Math.random(), category }));
+      .map((category, index) => Object.assign({}, { key: index, label: category }));
     this.setState({ categories: categoriesWithKeys });
   }
 
   handleSubmit() {
-    const categories = this.state.categories.map(categoryObject => categoryObject.category);
+    const categories = this.state.categories.map(categoryObject => categoryObject.label);
     this.setState({ show: false });
     this.props.updateOrganization({ categories });
   }

--- a/src/modules/organizations/containers/categories-container.jsx
+++ b/src/modules/organizations/containers/categories-container.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { setCurrentOrganization } from '../action-creators';
+import { organizationShape } from '../model';
+import CategoriesEditor from '../components/categories-editor';
+
+class CategoriesContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.resetOrganization = this.resetOrganization.bind(this);
+
+    this.state = {
+      categories: []
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      categories: this.props.organization.categories
+    });
+  }
+
+  handleSubmit() {
+    this.setState({ show: false });
+    this.props.updateOrganization({ categories: this.state.categories });
+  }
+
+  handleChange(categories) {
+    this.setState({ show: true, categories });
+  }
+
+  resetOrganization() {
+    this.setState({ show: false });
+    this.props.dispatch(setCurrentOrganization(this.props.organization));
+  }
+
+  render() {
+    return (
+      <div>
+        <h5>Categories</h5>
+        <div>
+          <span className="form__label" htmlFor="categories">
+            Project Categories
+            <CategoriesEditor
+              id="categories"
+              name="categories"
+              onChange={this.handleChange}
+              categories={this.state.categories}
+            />
+          </span>
+          <small className="form__help">
+            Categories blah blah blah.
+          </small>
+        </div>
+        {this.state.show &&
+        <div>
+          <button onClick={this.handleSubmit}>Save</button>
+          <button onClick={this.resetOrganization}>Cancel</button>
+        </div>}
+      </div>);
+  }
+}
+
+CategoriesContainer.defaultProps = {
+  organization: {},
+};
+
+CategoriesContainer.propTypes = {
+  dispatch: PropTypes.func,
+  organization: organizationShape,
+  updateOrganization: PropTypes.func
+};
+
+function mapStateToProps(state) {
+  return {
+    organization: state.organization,
+  };
+}
+
+export default connect(mapStateToProps)(CategoriesContainer);


### PR DESCRIPTION
Closes #90

Adds input for categories, drag-reorderable

[See PFE Issue 2970](https://github.com/zooniverse/Panoptes-Front-End/issues/2970)

Staged - https://categories.lab-preview.zooniverse.org/