### PR TITLE
remove form label styling

### DIFF
--- a/src/modules/common/components/external-links-editor.jsx
+++ b/src/modules/common/components/external-links-editor.jsx
@@ -86,7 +86,7 @@ export default class ExternalLinksEditor extends React.Component {
       });
 
     return (
-      <table className="external-links-table form__input--top-margin">
+      <table className="external-links-table">
         <thead>
           <tr>
             <th>Label</th>

--- a/src/modules/common/components/social-links-editor.jsx
+++ b/src/modules/common/components/social-links-editor.jsx
@@ -78,7 +78,7 @@ export default class SocialLinksEditor extends React.Component {
       .filter(item => socialUrls.map(url => url.site).indexOf(item) < 0);
     return (
       <div>
-        <table className="edit-social-links form__input--top-margin">
+        <table className="edit-social-links">
           <DragReorderable
             tag="tbody"
             items={socialUrls}

--- a/src/modules/organizations/components/about-page.jsx
+++ b/src/modules/organizations/components/about-page.jsx
@@ -33,13 +33,12 @@ const AboutPage = (props) => {
       </p>
       <FormContainer onSubmit={props.onSubmit} onReset={props.resetOrganizationPage}>
         <fieldset className="form__fieldset">
-          <label className="form__label" htmlFor="content">
+          <label htmlFor="content">
             About Page Content
             <br />
             <MarkdownEditor
               id="content"
               name="content"
-              className="form__input--top-margin"
               onChange={props.onTextAreaChange}
               project={props.organization}
               rows="20"

--- a/src/modules/organizations/components/organization-add-project.jsx
+++ b/src/modules/organizations/components/organization-add-project.jsx
@@ -15,7 +15,7 @@ const OrganizationAddProject = ({ value, onAdd, onChange, onReset }) =>
       <ProjectSearch clearable={false} onChange={onChange} value={value} />
     </FormContainer>
     <br />
-    <span className="form__label">Instructions</span>
+    <strong>Instructions</strong>
     <ul className="organization-layout__section-instructions">
       <li className="organization-layout__section-instructions--list-items">
         You must be a project&apos;s owner or collaborator to add a project to the organization.

--- a/src/modules/organizations/containers/collaborator-creator-container.jsx
+++ b/src/modules/organizations/containers/collaborator-creator-container.jsx
@@ -74,7 +74,7 @@ class CollaboratorCreatorContainer extends React.Component {
       >
         <h4 className="collaborators__title">Add another user role</h4>
         <fieldset className="form__fieldset">
-          <label htmlFor="user-search" className="form__label">Find a user</label>
+          <label htmlFor="user-search">Find a user</label>
           <UserSearch id="user-search" ref={(input) => { this.userSearch = input; }} />
         </fieldset>
 
@@ -84,7 +84,7 @@ class CollaboratorCreatorContainer extends React.Component {
               return (
                 <span key={ID_PREFIX + role}>
                   <dt>
-                    <strong><label className="form__label" htmlFor={ID_PREFIX + role}>
+                    <strong><label htmlFor={ID_PREFIX + role}>
                       <input
                         ref={(input) => { this[ID_PREFIX + role] = input; }}
                         id={ID_PREFIX + role}

--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -68,10 +68,9 @@ class DetailsFormContainer extends React.Component {
         <h5>Details</h5>
         <FormContainer onSubmit={this.handleSubmit} onReset={this.resetOrganization}>
           <fieldset className="form__fieldset">
-            <label className="form__label">
+            <label>
               <DisplayNameSlugEditor
                 origin={config.zooniverseURL}
-                className="org-details-slug-editor"
                 resource={organization}
                 resourceType="organization"
                 ref={(node) => { this.fields.display_name = node; }}
@@ -79,7 +78,7 @@ class DetailsFormContainer extends React.Component {
             </label>
           </fieldset>
           <fieldset className="form__fieldset">
-            <label className="form__label">
+            <label>
               Description
               <DescriptionInput
                 className="form__input form__input--full-width"
@@ -94,12 +93,11 @@ class DetailsFormContainer extends React.Component {
             </small>
           </fieldset>
           <fieldset className="form__fieldset">
-            <label className="form__label">
+            <label>
               Introduction
               <MarkdownEditor
                 id="introduction"
                 name="introduction"
-                className="form__input--top-margin"
                 onChange={this.handleTextAreaChange}
                 project={this.props.organization}
                 rows="10"

--- a/src/modules/organizations/containers/links-container.jsx
+++ b/src/modules/organizations/containers/links-container.jsx
@@ -45,7 +45,7 @@ class LinksContainer extends React.Component {
       <div>
         <h5>Links</h5>
         <div>
-          <label className="form form__label">
+          <label>
             External Links
             <ExternalLinksEditor
               id="external"
@@ -61,7 +61,7 @@ class LinksContainer extends React.Component {
         </div>
         <br />
         <div className="form__fieldset">
-          <label className="form form__label">
+          <label>
             Social Links
             <SocialLinksEditor
               id="social"

--- a/src/styles/components/edit-details.styl
+++ b/src/styles/components/edit-details.styl
@@ -9,20 +9,8 @@
 
     .forms__aside
       flex: 1 1
-      margin-right: 1.5vw
       line-height: 1.25
+      margin-right: 1.5vw
 
     .forms__section
       flex-grow: 5
-
-    .org-details-slug-editor__form-input
-      margin-top: 0.5em
-      display: block
-      border: 1px solid
-      border-radius: 2px
-      box-shadow: 1px 2px 5px -1px rgba(0,0,0,0.2) inset
-      box-sizing: border-box
-      padding: 0.5em 1vw
-      width: 100%
-    .org-details-slug-editor__form-help
-      font-size: .9em

--- a/src/styles/components/image-selector.styl
+++ b/src/styles/components/image-selector.styl
@@ -8,7 +8,6 @@
     height: 100%
     width: 100%
     text-align: center
-    padding: 1em 0
 
     &--without-border
       @extends .image-selector__uploader

--- a/src/styles/global/form.styl
+++ b/src/styles/global/form.styl
@@ -9,12 +9,9 @@
     box-sizing: border-box
     display: block
     padding: .5em 1vw
-    margin-top: 0.5em
 
     &--full-width
       width: 100%
-    &--top-margin
-      margin-top: 0.5em
 
   &__help
     font-size: .9em


### PR DESCRIPTION
I think there were three things related to form labels:
a. unrelated to the PR, but from long ago, the class `form__labels` was being used when it wasn't an actual form label, but to make a sub-section heading styled differently, or specifically in all caps and small
b. per design input, we decided these sub-section headings shouldn't be in all-caps or smaller, but should be styled what turned out to be as they would be by default
c. per design input, these sub-section headings should have a little extra margin

point c I think is overcomplicating the PR, and while we should certainly revisit, I think might be best to punt on for now