### PR TITLE
Conditionally render the Listed At field.

### DIFF
--- a/src/modules/organizations/components/edit-details.jsx
+++ b/src/modules/organizations/components/edit-details.jsx
@@ -66,10 +66,9 @@ const EditDetails = (props) => {
                 </span>
               </span>
               <br />
-              <span>
-                Listed At:{' '}
-                {props.organization.listed ? listedAtDate : 'N/A'}
-              </span>
+              {props.organization.listed
+                ? <span>Listed At: {listedAtDate}</span>
+                : null }
             </div>
             <small>
               Status indicates whether an organization is publicly visible (TRUE) or not publicly visible (FALSE).

--- a/test/modules/organizations/components/edit-details-test.js
+++ b/test/modules/organizations/components/edit-details-test.js
@@ -12,7 +12,7 @@ import ImageSelector from '../../../../src/modules/common/containers/image-selec
 const listedOrganization = organizations[0];
 const unlistedOrganization = organizations[1];
 
-describe('<EditDetails />', function() {
+describe.only('<EditDetails />', function() {
   let wrapper;
   const deleteOrganizationSpy = sinon.spy();
 
@@ -51,8 +51,19 @@ describe('<EditDetails />', function() {
     expect(wrapper.find('span').last().text()).to.equal(`Listed At: ${formattedDate}`);
   });
 
-  it('should render "N/A" when passed an unlisted organization', function() {
+  it('should render true when passed a listed organization', function() {
+    const orgStatus = wrapper.find('span').at(1).children().text();
+    expect(orgStatus).to.equal('true');
+  });
+
+  it('should render false when passed an unlisted organization', function() {
     wrapper.setProps({ organization: unlistedOrganization });
-    expect(wrapper.find('span').last().text()).to.equal('Listed At: N/A');
+    const orgStatus = wrapper.find('span').at(1).children().text();
+    expect(orgStatus).to.equal('false');
+  });
+
+  it('should not render a Listed At field for an unlisted organization', function() {
+    const orgStatusWrapper = wrapper.find('div').at(5);
+    expect(orgStatusWrapper.children()).to.have.lengthOf(2);
   });
 });


### PR DESCRIPTION
## PR Overview
- Updates the UI to only show the "Listed At" field for orgs where `listed={true}`.
  - For orgs where `listed={true}`, the formatted `Listed At` date still renders the same as it did previously.
- Previously, the UI displayed 'N/A' for orgs where `listed={false}` (see screen shot below).
- [Staged here](https://conditional-render-listed-at.lab-preview.zooniverse.org/).

Previous display for not listed org:
![image](https://user-images.githubusercontent.com/12473119/32677420-fb0411e4-c623-11e7-9389-54cc40ffe832.png)

New display for not listed org:
![image](https://user-images.githubusercontent.com/12473119/32677604-ae5fe81c-c624-11e7-9ae3-b342a54a1cd0.png)
