### PR TITLE
Fixes for org with null props, empty linked projects

### DIFF
--- a/src/modules/organizations/containers/details-form-container.jsx
+++ b/src/modules/organizations/containers/details-form-container.jsx
@@ -36,10 +36,11 @@ class DetailsFormContainer extends React.Component {
   }
 
   setFields() {
+    const { description, introduction, announcement } = this.props.organization;
     const fields = {
-      description: this.props.organization.description.slice(),
-      introduction: this.props.organization.introduction.slice(),
-      announcement: this.props.organization.announcement.slice()
+      description: description ? description.slice() : '',
+      introduction: introduction ? introduction.slice() : '',
+      announcement: announcement ? announcement.slice() : ''
     };
     this.setState({ fields });
   }

--- a/src/modules/organizations/containers/organizations-list-container.jsx
+++ b/src/modules/organizations/containers/organizations-list-container.jsx
@@ -72,7 +72,6 @@ class OrganizationsListContainer extends React.Component {
     // TODO We shouldn't be setting the title.
     const name = `Untitled organization ${new Date().toLocaleString()}`;
     apiClient.type('organizations').create({
-      description: 'Lorem Ipsum',
       display_name: name,
       primary_language: counterpart.getLocale()
     })

--- a/src/modules/organizations/containers/projects-container.jsx
+++ b/src/modules/organizations/containers/projects-container.jsx
@@ -52,8 +52,10 @@ class ProjectsContainer extends React.Component {
 
     organization.get('projects', query)
       .then((projects) => {
-        this.setState({ meta: projects[0].getMeta() });
-        this.props.dispatch(setOrganizationProjects(projects));
+        if (projects && projects.length > 0) {
+          this.setState({ meta: projects[0].getMeta() });
+          this.props.dispatch(setOrganizationProjects(projects));
+        }
       })
       .catch((error) => {
         const notification = { status: 'critical', message: `${error.statusText}: ${error.message}` };


### PR DESCRIPTION
Closes #181.

https://new-org-issues.lab-preview.zooniverse.org/

- fixes issue in Edit section for `null` introduction or announcement
- fixes issue in Projects section for empty array response for linked projects

To reproduce issues create a new org, check Edit section (which it'll default to on creation) and Projects section.