### PR TITLE
Update ZRC and most recent audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,11 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "animated-scrollto": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/animated-scrollto/-/animated-scrollto-1.1.0.tgz",
+      "integrity": "sha1-c1AS2ji/l9M3CH+WnZu+aiTErLw="
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -4972,8 +4977,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4994,14 +4998,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5014,20 +5016,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5142,8 +5141,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5155,7 +5153,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5170,7 +5167,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5281,8 +5277,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5294,7 +5289,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5415,7 +5409,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5435,7 +5428,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5464,8 +5456,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
@@ -5674,7 +5665,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -7080,8 +7070,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -7123,7 +7112,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -8257,7 +8245,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -8267,8 +8254,7 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10105,6 +10091,28 @@
         "react-input-autosize": "^2.1.0"
       }
     },
+    "react-swipe": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-swipe/-/react-swipe-5.1.1.tgz",
+      "integrity": "sha512-7o4rktmVVTQaZk5MoibL3tR9tA/5qLy8jlKLtMn7IcDl6nj7Vafb7OIuqExWoPNb/Xe1SLTnwEoaHICGKDCGew==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0",
+        "swipe-js-iso": "^2.0.4"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
     "react-transition-group": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
@@ -11884,6 +11892,11 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "swipe-js-iso": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/swipe-js-iso/-/swipe-js-iso-2.1.5.tgz",
+      "integrity": "sha512-yTTU5tDYEvtKfCD8PN+Rva25acJwogUCd6wPT1n1im/MOJlg6PtHiPKaaNK7HDBiIrWThA/WRbJZbox2letghg=="
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -13549,19 +13562,60 @@
       }
     },
     "zooniverse-react-components": {
-      "version": "github:zooniverse/Zooniverse-React-Components#87f4e902fd94957d86a16036ca4d46cc3bb4e012",
-      "from": "github:zooniverse/Zooniverse-React-Components#v0.5.0",
+      "version": "github:zooniverse/Zooniverse-React-Components#967fda93517c9fad853c298633e7555262215357",
+      "from": "github:zooniverse/Zooniverse-React-Components#v0.7.3",
       "requires": {
+        "animated-scrollto": "^1.1.0",
         "data-uri-to-blob": "0.0.4",
         "grommet": "^1.8.2",
-        "modal-form": "^2.4.3",
-        "panoptes-client": "^2.5.2",
+        "markdownz": "^7.6.5",
+        "modal-form": "^2.8.0",
+        "panoptes-client": "^2.12.2",
         "prop-types": "~15.5.10",
         "react": "^15.6.1",
         "react-dom": "^15.6.1",
-        "react-select": "^1.0.0-rc.5"
+        "react-select": "^1.0.0-rc.5",
+        "react-swipe": "^5.0.8"
       },
       "dependencies": {
+        "json-api-client": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-4.0.2.tgz",
+          "integrity": "sha512-Hxki1EGD8J3hdvAWo6cQy5aCcVH/VT6hzrYF9VTuy6lkvZaXPfodQR5p5Vh2Zc/SUl/yvcp2l7RHPiqUgpzQmA==",
+          "requires": {
+            "normalizeurl": "~0.1.3",
+            "superagent": "^3.8.3"
+          }
+        },
+        "markdownz": {
+          "version": "7.6.5",
+          "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.5.tgz",
+          "integrity": "sha512-GKgR/UZoUkDgHYGxop5Yse3xQmq6Cmw6RQ2doGXCYzELcmUPGkEAmXNZ/QZo2OWzsOokz2pJwa6SwJC6JQ/oxg==",
+          "requires": {
+            "markdown-it": "~8.4.1",
+            "markdown-it-anchor": "~5.0.2",
+            "markdown-it-container": "~2.0.0",
+            "markdown-it-emoji": "~1.2.0",
+            "markdown-it-footnote": "~3.0.1",
+            "markdown-it-html5-embed": "~1.0.0",
+            "markdown-it-imsize": "~2.0.1",
+            "markdown-it-sub": "~1.0.0",
+            "markdown-it-sup": "~1.0.0",
+            "markdown-it-table-of-contents": "~0.4.0",
+            "markdown-it-video": "~0.4.0",
+            "twemoji": "~1.4.1"
+          }
+        },
+        "panoptes-client": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.12.2.tgz",
+          "integrity": "sha512-A8+Fs9F6neXfPnZGybGLaQUlPLaTHUyBnklzbT0jPPmp4GMdDGlHwJSPuTIUCCm8pgMEoI/5U6s/VGyUSLHRFQ==",
+          "requires": {
+            "json-api-client": "^4.0.2",
+            "local-storage": "^1.4.2",
+            "sugar-client": "^1.0.1"
+          }
+        },
         "react": {
           "version": "15.6.2",
           "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "redux-devtools-extension": "~1.0.0",
     "redux-thunk": "~2.1.0",
     "zoo-grommet": "~0.3.0",
-    "zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#v0.5.0"
+    "zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#v0.7.3"
   },
   "devDependencies": {
     "babel-cli": "~6.26.0",


### PR DESCRIPTION
Updates ZRC to latest and runs npm audit fix again. The automated fix doesn't update installs via github. Everything seems to work, but there are a few tests broken so I'm not 100% sure. These tests are broken on master so I don't think the updates are related. 