### PR TITLE
Set Cache-Control headers

### DIFF
--- a/bin/upload.js
+++ b/bin/upload.js
@@ -1,0 +1,29 @@
+/*
+  An S3 uploader with some useful default settings for Zooniverse static files.
+  Accepts a local path and an S3 path, relative to zooniverse-static, as its arguments.
+  Usage example: node upload.js dist preview.zooniverse.org/pfe-lab/cache-control
+*/
+const Uploader = require('s3-batch-upload').default;
+
+const args = process.argv.slice(2);
+const [ localPath, remotePath ] = args;
+
+async function uploadBuild() {
+  const uploader = new Uploader({
+    bucket: 'zooniverse-static',
+    localPath,
+    remotePath,
+    concurrency: '200',
+    cacheControl: {
+      '**/index.html': 'max-age=60',
+      '**/*.*': 'public, max-age=604800, immutable'
+    },
+    accessControlLevel: 'public-read'
+  });
+
+  const files = await uploader.upload();
+  console.log('Uploaded to S3');
+  console.log(files.join('\n'));
+}
+
+uploadBuild();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "export HEAD_COMMIT=$(git rev-parse --short HEAD); export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3777  -- webpack-dev-server --config ./webpack.config.js",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.production.config.js -p",
-    "_publish": "s3-batch-upload -b zooniverse-static -p ./dist -C 200 -acl 'public-read' -r \"$PATH_ROOT/$SUBDIR\"",
+    "_publish": "node ./bin/upload.js dist \"$PATH_ROOT/$SUBDIR\"",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.lab-preview.zooniverse.org/\"",
     "_stage": "export PATH_ROOT=preview.zooniverse.org/pfe-lab; npm run _build && npm run _publish && npm run _log-staging-url",
     "stage": "export NODE_ENV=staging; export SUBDIR=$(git symbolic-ref --short HEAD | awk '{print tolower($0)}'); npm run _stage",


### PR DESCRIPTION
Move the S3 upload config into its own script.
Set Cache-Control headers:
- 60s for index.html.
- 1 week for other static assets.