### PR TITLE
Remove the -p flag from builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "start": "export HEAD_COMMIT=$(git rev-parse --short HEAD); export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3777  -- webpack-dev-server --config ./webpack.config.js",
-    "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.production.config.js -p",
+    "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.production.config.js",
     "_publish": "node ./bin/upload.js dist \"$PATH_ROOT/$SUBDIR\"",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.lab-preview.zooniverse.org/\"",
     "_stage": "export PATH_ROOT=preview.zooniverse.org/pfe-lab; npm run _build && npm run _publish && npm run _log-staging-url",


### PR DESCRIPTION
`webpack -p` adds `--define process.env.NODE_ENV="'production'"`, which forces staging builds to use the production API.

Closes #199.