### PR TITLE
Update README, PR template, .travis.yml

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Staging branch URL: https://pr-{NUMBER}.lab-preview.zooniverse.org/
+
+Fixes # .
+
+Describe your changes.
+
+# Review Checklist
+
+- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
+- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
+- [ ] Are the tests passing locally and on Travis?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: node_js
-node_js: "8.0.0"
+node_js: "10"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ __When you are done, create a production-ready version of the JS bundle:__
 
 ## Deployment
 
-Merges to the `master` branch trigger a production build and deployment.
-Opening a PR triggers a staging build and deployment.
+A merge to the `master` branch automatically creates a production build and deploys to https://lab.zooniverse.org/.
+Opening a PR creates a staging build and deploys to a url based on the PR # (i.e. PR-123 => https://pr-123.lab-preview.zooniverse.org/).
 
 Builds and deployments utilize [Docker](https://github.com/zooniverse/pfe-lab/blob/master/Dockerfile) and the pfe-lab [Jenkins project](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/pfe-lab/).
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,21 @@ __When you are done, create a production-ready version of the JS bundle:__
 
 ```npm run build```
 
-
 ## Testing
-- If you write a new component, write a test. Each component should have its own `-test.js` file. 
+
+- If you write a new component, write a test. Each component should have its own `-test.js` file.
 - The test runner is [Mocha](https://mochajs.org/), assertion library is [Chai](http://chaijs.com/), and [Enzyme](http://airbnb.io/enzyme/) is available for testing React components. [Sinon](http://sinonjs.org/) is used for standalone test spies, stubs, and mocks.
 - You can run the tests with `npm run test`.
 
+## Deployment
+
+Merges to the `master` branch trigger a production build and deployment.
+Opening a PR triggers a staging build and deployment.
+
+Builds and deployments utilize [Docker](https://github.com/zooniverse/pfe-lab/blob/master/Dockerfile) and the pfe-lab [Jenkins project](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/pfe-lab/).
+
 ## CSS Conventions
+
 - Keep common base styles and variables in **common.styl**. 
 - For a given component, pick a unique top-level class name for that component and nest child classes under it. 
 - Stylus formatting: Yes colons, no semicolons, no braces. 
@@ -36,6 +44,7 @@ __When you are done, create a production-ready version of the JS bundle:__
 - We are using [BEM](http://getbem.com/introduction/) for CSS naming conventions.
 
 ## ESLint
+
 - An [ESLint](https://eslint.org/) configuration file is setup in the root of the repository for you to use with your text editor to lint both ES6 and use [Airbnb's React style guide](https://github.com/airbnb/javascript/tree/master/react).
 - ESLint can be run from the CLI with `eslint path/to/local/file.jsx`.
 


### PR DESCRIPTION
Staged at https://pr-223.lab-preview.zooniverse.org/ (though no changes on actual site).

Changes made:
- updates README noting `master` merge automatically builds and deploys to production
- updates README noting PRs' staging build and variable deployment
- creates PR template including note on variable staging deployment
- updates `.travis.yml` to fix build error (i.e. [Build 50](https://travis-ci.com/github/zooniverse/pfe-lab/builds/212259980))

Largely documentation update per #214.