### PR TITLE
Use staging npm command in staging deploy

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: '14.x'
     - run: npm install
-    - run: npm run _build-production
+    - run: npm run _build
 
     - name: Upload to blob storage
       id: upload


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.lab-preview.zooniverse.org/

Don't use the `_build-production` npm command on staging

Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are the tests passing locally and on Travis?
