### PR TITLE
Upgrade to Node 14. Remove Travis for GA

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,22 @@
+name: Run PFE Lab Tests
+
+on:
+    # Run this workflow on creation (or sync to source branch) of a new pull request
+    pull_request:
+
+    # Allow running this workflow manually from the Actions tab
+    workflow_dispatch:
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Node.js build
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - run: npm ci
+    - run: npm test
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: node_js
-node_js: "10"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 WORKDIR /src
 RUN chown -R node:node /src

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha"
   },
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "author": "Zooniverse",


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.lab-preview.zooniverse.org/

Updates to Node 14 and removes Travis in favor of Github Actions for running tests.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are the tests passing locally and on Travis?
