### PR TITLE
Add GA for master branch deployment

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: '14.x'
     - run: npm install
-    - run: npm run _build
+    - run: npm run _build-staging
 
     - name: Upload to blob storage
       id: upload

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -90,3 +90,4 @@ jobs:
     - name: logout
       run: |
             az logout
+            

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,92 @@
+name: Deploy PFE-Lab Staging
+
+on:
+    # Run this workflow on creation (or sync to source branch) of a new pull request
+    push:
+        branches:
+          - master
+
+jobs:
+  deploy_staging:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: azure/login@v1
+      with:
+          creds: ${{ secrets.AZURE_STATIC_SITES }}
+
+    - name: Node.js build
+      id: build
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - run: npm install
+    - run: npm run _build-staging
+
+    - name: Upload to blob storage
+      id: upload
+      uses: azure/CLI@v1
+      with:
+        creds: ${{ secrets.AZURE_STATIC_SITES }}
+        inlineScript: |
+            az storage blob upload-batch \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, immutable, max-age=604800' \
+              --destination '$web/preview.zooniverse.org/pfe-lab/master' \
+              --source ./dist
+            az storage blob upload \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, max-age=60' \
+              --container-name '$web' \
+              --name 'preview.zooniverse.org/pfe-lab/master/index.html' \
+              --file ./dist/index.html
+    - name: Slack notification
+      uses: 8398a7/action-slack@v3
+      if: always()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        fields: took
+        status: custom
+        custom_payload: |
+          {
+            "channel": "#deploys",
+            "icon_emoji": ":octocat:",
+            "username": "Deploy Action",
+            "attachments": [{
+              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              "mrkdwn_in": ["text"],
+              "author_name": "${{ github.actor }}",
+              "author_link": "https://github.com/${{ github.actor }}/",
+              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
+              "title": "PFE-Lab Staging deploy complete",
+              "title_link": "https://master.lab-preview.zooniverse.org",
+              "fields": [
+                  {
+                      "title": "Status",
+                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
+                      "short": true
+                  },
+                  {
+                      "title": "Triggered by",
+                      "value": "${{ github.event_name }}",
+                      "short": true
+                  },
+                  {
+                      "title": "Initiated by",
+                      "value": "<https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|${{ github.event.pull_request.title }}>"
+                  },
+                  {
+                      "title": "Run Link",
+                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+              ],
+              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
+              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
+              "footer_icon": "https://www.zooniverse.org/favicon.ico"
+            }]
+          }
+# Azure logout
+    - name: logout
+      run: |
+            az logout

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Deployment is handled by Github Action. Both staging and production deployment c
 
 ### Staging
 
-On opening of pull requests, a Github Action is triggered to deploy to staging. The blob storage location depends on the pull request number, e.g. `https://pr-214.lab-preview.zooniverse.org`. Note: For authentication, you will need to add the staged URL to Doorkeeper.
+On opening of pull requests, a Github Action is triggered to deploy to a branch staging location. The blob storage location depends on the pull request number, e.g. `https://pr-214.lab-preview.zooniverse.org`. Note: For authentication, you will need to add the staged URL to Doorkeeper.
+
+On push to master, a Github Action is triggered to deploy to master staging found at `https://master.lab-preview.zooniverse.org`. 
 
 ### Production
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "start": "export HEAD_COMMIT=$(git rev-parse --short HEAD); export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3777  -- webpack-dev-server --config ./webpack.config.js",
     "_build-production": "export NODE_ENV=production; npm run _build",
+    "_build-staging": "export NODE_ENV=staging; npm run _build",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.production.config.js",
     "eslint": "eslint .",
     "test": "NODE_ENV=development BABEL_ENV=test mocha"


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.lab-preview.zooniverse.org/

Adds the master branch deployment that we missed and explicitly set node env for staging.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are the tests passing locally and on Travis?
