### PR TITLE
Build with Node 18 (lts/hydrogen)

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -10,7 +10,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: 'lts/hydrogen'
       output: 'dist'
       script: '_build-staging'
   deploy:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -12,7 +12,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: 'lts/hydrogen'
       output: 'dist'
       script: '_build-production'
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -11,7 +11,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: 'lts/hydrogen'
       output: 'dist'
       script: '_build-staging'
   deploy:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
@@ -22,17 +22,10 @@ jobs:
         ssh://git@github.com/
 
     - name: Node.js build
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
-
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        node-version: 'lts/hydrogen'
+        cache: 'npm'
 
     - run: npm ci
     - run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18-alpine
 
 WORKDIR /src
 RUN chown -R node:node /src

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "webpack-dev-server": "~4.11.1"
       },
       "engines": {
-        "node": ">=16",
+        "node": ">=18",
         "npm": ">=8"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "_build-staging": "export NODE_ENV=staging; npm run _build",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.production.config.js",
     "eslint": "eslint .",
-    "test": "NODE_ENV=development BABEL_ENV=test mocha"
+    "test": "NODE_ENV=development BABEL_ENV=test mocha --exit"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=8"
   },
   "author": "Zooniverse",

--- a/test/utils/dom.js
+++ b/test/utils/dom.js
@@ -1,6 +1,9 @@
 /* eslint-disable */
 var jsdom = require('jsdom');
+var nock = require('nock');
 const { JSDOM } = jsdom;
+// require all net requests to be mocked.
+nock.disableNetConnect()
 
 // setup the simplest document possible
 const { document } = (new JSDOM(`<!doctype html><html><body></body></html>`, { url: 'http://localhost' })).window;


### PR DESCRIPTION
- update `package.json`.
- update Dockerfile.
- update GitHub workflows.

Node 16 entered maintenance mode in October 2022 and support ends in September 2023. 

Staging branch URL: https://pr-401.lab-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are the tests passing locally and on Travis?
