### PR TITLE
Fix JS Asset Loading

### DIFF
--- a/src/styles/components/landing.styl
+++ b/src/styles/components/landing.styl
@@ -1,6 +1,6 @@
 .landing
   align-items: center
-  background: url('../images/builder-landing.jpg') center center no-repeat
+  background: url('https://lab.zooniverse.org/src/images/builder-landing.jpg') center center no-repeat
   background-size: cover
   color: white
   display: flex

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,8 @@ module.exports = {
 
   output: {
     path: path.join(__dirname, '/dist/'),
-    filename: '[name].js'
+    filename: '[name].js',
+    publicPath: '/'
   },
 
   plugins: [

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -34,7 +34,8 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist/'),
     filename: '[name]-[chunkhash].js',
-    chunkFilename: '[name]-[chunkhash].js'
+    chunkFilename: '[name]-[chunkhash].js',
+    publicPath: '/'
   },
 
   plugins: [


### PR DESCRIPTION
Attempt to fix issue causing JS asset loading to 404.

Fixes #250
Reverts #225

Staging branch URL: https://pr-684.lab-preview.zooniverse.org/

# To Review
- Does an organization editing page (e.g., https://lab.zooniverse.org/organizations/85) load correctly?

# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are the tests passing locally and on Travis?
