### PR TITLE
fix project selection dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "~16.14.0",
         "react-redux": "~5.1.1",
         "react-router": "~3.2.1",
-        "react-select": "~1.0.0-rc.3",
+        "react-select": "1.0.0-rc.10",
         "redux": "~3.6.0",
         "redux-devtools-extension": "~1.0.0",
         "redux-thunk": "~2.4.2",
@@ -11988,13 +11988,18 @@
       }
     },
     "node_modules/react-select": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.1.tgz",
-      "integrity": "sha512-488j7KOR/48OSfrOuQsGpZldY2Tuv2BIcaJ3uPZ4EgQDZnwyxGl4hCGkhsu8mkEGu38oPEjqoNacG+j/nktfWQ==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
+      "integrity": "sha512-SgvricWxrvC3FvOdwUTi+cquuRa/93DvZVpsiQwkE8uyYxU5ab47+mEQEE2GqhakZxzT9/iksZBc39vC4Vgp6w==",
+      "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.4",
         "prop-types": "^15.5.8",
-        "react-input-autosize": "^2.1.0"
+        "react-input-autosize": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0",
+        "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0"
       }
     },
     "node_modules/react-swipe": {
@@ -15771,20 +15776,6 @@
       "peerDependencies": {
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/react-select": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
-      "integrity": "sha512-SgvricWxrvC3FvOdwUTi+cquuRa/93DvZVpsiQwkE8uyYxU5ab47+mEQEE2GqhakZxzT9/iksZBc39vC4Vgp6w==",
-      "dependencies": {
-        "classnames": "^2.2.4",
-        "prop-types": "^15.5.8",
-        "react-input-autosize": "^2.0.1"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0",
-        "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0"
       }
     }
   },
@@ -24784,13 +24775,13 @@
       }
     },
     "react-select": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.1.tgz",
-      "integrity": "sha512-488j7KOR/48OSfrOuQsGpZldY2Tuv2BIcaJ3uPZ4EgQDZnwyxGl4hCGkhsu8mkEGu38oPEjqoNacG+j/nktfWQ==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
+      "integrity": "sha512-SgvricWxrvC3FvOdwUTi+cquuRa/93DvZVpsiQwkE8uyYxU5ab47+mEQEE2GqhakZxzT9/iksZBc39vC4Vgp6w==",
       "requires": {
         "classnames": "^2.2.4",
         "prop-types": "^15.5.8",
-        "react-input-autosize": "^2.1.0"
+        "react-input-autosize": "^2.0.1"
       }
     },
     "react-swipe": {
@@ -27566,18 +27557,6 @@
         "prop-types": "^15.7.2",
         "react-select": "1.0.0-rc.10",
         "react-swipe": "^6.0.4"
-      },
-      "dependencies": {
-        "react-select": {
-          "version": "1.0.0-rc.10",
-          "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
-          "integrity": "sha512-SgvricWxrvC3FvOdwUTi+cquuRa/93DvZVpsiQwkE8uyYxU5ab47+mEQEE2GqhakZxzT9/iksZBc39vC4Vgp6w==",
-          "requires": {
-            "classnames": "^2.2.4",
-            "prop-types": "^15.5.8",
-            "react-input-autosize": "^2.0.1"
-          }
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "~16.14.0",
     "react-redux": "~5.1.1",
     "react-router": "~3.2.1",
-    "react-select": "~1.0.0-rc.3",
+    "react-select": "1.0.0-rc.10",
     "redux": "~3.6.0",
     "redux-devtools-extension": "~1.0.0",
     "redux-thunk": "~2.4.2",

--- a/src/modules/common/components/project-search.jsx
+++ b/src/modules/common/components/project-search.jsx
@@ -15,7 +15,7 @@ const ProjectSearch = ({ clearable, onChange, value }) => {
     }).then((projects) => {
       const opts = projects.map(project => ({
         value: project.id,
-        label: project.display_name,
+        label: `${project.display_name} (${project.slug})`
       }));
       return { options: opts };
     });

--- a/src/modules/organizations/containers/projects-container.jsx
+++ b/src/modules/organizations/containers/projects-container.jsx
@@ -131,7 +131,7 @@ class ProjectsContainer extends React.Component {
           onAdd={this.addProject}
           onChange={this.changeSelectedProject}
           onReset={this.resetProjectToAdd}
-          value={this.state.projectToAdd.value}
+          value={this.state.projectToAdd}
         />
       </div>
     );


### PR DESCRIPTION
Staging branch URL: https://pr-780.lab-preview.zooniverse.org/

Fixes #222 

- Bumping react-select to 1.0.0-rc10 to match PFE and other repos.
- Pass full option object (value and label) to search component, which fixes primary bug by displaying label of selected item before clicking "Add project" confirmation.
- Added slug to option label to help differentiate between projects when working in admin mode (where there are many duplicates with the same display name).

For review, feel free to test adding projects to org using by test org on staging: https://pr-780.lab-preview.zooniverse.org/organizations/59/